### PR TITLE
Clarify extra controls toggle label and behavior

### DIFF
--- a/rekap.html
+++ b/rekap.html
@@ -22,7 +22,7 @@
   <section class="card section">
     <div class="row">
       <button id="btnOpenForm">form baru</button>
-      <button id="btnToggleControls" aria-expanded="false" title="Tampilkan opsi lain">⋮</button>
+      <button id="btnToggleControls" aria-expanded="false" title="Tampilkan opsi lain">Tampilkan opsi</button>
       <div id="extraControls" class="is-hidden">
         <span id="seqBadge" class="badge">Next: ?new=1</span>
         <button id="btnResetSeq">Reset Nomor (?new=1)</button>
@@ -72,10 +72,15 @@ tr.innerHTML = `
   const toggleBtn=document.getElementById('btnToggleControls');
   const extraControls=document.getElementById('extraControls');
   if(toggleBtn && extraControls){
-    toggleBtn.addEventListener('click', ()=>{
-      extraControls.classList.toggle('is-hidden');
+    const syncToggleState=()=>{
       const expanded=!extraControls.classList.contains('is-hidden');
       toggleBtn.setAttribute('aria-expanded', String(expanded));
+      toggleBtn.textContent=expanded?'Sembunyikan opsi':'Tampilkan opsi';
+    };
+    syncToggleState();
+    toggleBtn.addEventListener('click', ()=>{
+      extraControls.classList.toggle('is-hidden');
+      syncToggleState();
     });
   }
   document.getElementById('btnReload').addEventListener('click', render);


### PR DESCRIPTION
## Summary
- replace the extra controls toggle button glyph with descriptive text for clarity
- update the toggle handler to keep aria-expanded and button text in sync with visibility
- ensure the hidden-by-default state continues to show "Tampilkan opsi" until expanded

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8ec3e8b408333b5b001019f324b65