### PR TITLE
Restore stored period dates on form load

### DIFF
--- a/form.html
+++ b/form.html
@@ -94,7 +94,19 @@ async function tryServerSet(key, data){ try{ await fetch('/.netlify/functions/st
   const histStart=p.get('histStart');
   const histEnd=p.get('histEnd');
   const histLegacy=p.get('hist'); // kompat lama
-  if(!(histStart||histLegacy)){ rerender(); return; }
+  const newN = p.get('new');
+  if(!(histStart||histLegacy)){
+    if(!newN){
+      const storedStart = localStorage.getItem('upah20_periodStart')||'';
+      const storedEnd = localStorage.getItem('upah20_periodEnd')||'';
+      const ps=document.getElementById('periodStart');
+      const pe=document.getElementById('periodEnd');
+      if(ps) ps.value=storedStart||'';
+      if(pe) pe.value=storedEnd||'';
+    }
+    rerender();
+    return;
+  }
 
   const keysToTry=[];
   if(histStart) keysToTry.push(PREFIX+histStart+'__'+(histEnd||'na'));


### PR DESCRIPTION
## Summary
- load saved period start and end values from localStorage when opening the form without history parameters
- preserve the virtual copy reset behaviour by skipping saved date restoration when `?new=` is present

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0c52aa1f88333b8b1aa916730c8a7