### PR TITLE
Add helper module for auto-opening form sessions

### DIFF
--- a/assets/js/nav.js
+++ b/assets/js/nav.js
@@ -1,0 +1,44 @@
+const STORAGE_KEY = "upah:new_counter";
+let memoryCounter = 0;
+
+function incrementFromStorage() {
+  const rawValue = window.localStorage.getItem(STORAGE_KEY);
+  const parsedValue = Number.parseInt(rawValue ?? "", 10);
+  const safeCurrent = Number.isFinite(parsedValue) && parsedValue >= 0 ? parsedValue : 0;
+  const nextValue = safeCurrent + 1;
+  window.localStorage.setItem(STORAGE_KEY, String(nextValue));
+  return nextValue;
+}
+
+export function getNextFormIndex() {
+  if (typeof window === "undefined") {
+    memoryCounter += 1;
+    return memoryCounter;
+  }
+
+  try {
+    return incrementFromStorage();
+  } catch (error) {
+    memoryCounter += 1;
+    return memoryCounter;
+  }
+}
+
+export function openNewFormAutoClose() {
+  const nextIndex = getNextFormIndex();
+  const targetUrl = `form.html?new=${encodeURIComponent(nextIndex)}&session=autoclose`;
+
+  if (typeof window !== "undefined") {
+    try {
+      if (window.location && typeof window.location.href === "string") {
+        window.location.href = targetUrl;
+      } else {
+        window.open(targetUrl, "_self");
+      }
+    } catch (error) {
+      window.open(targetUrl, "_self");
+    }
+  }
+
+  return targetUrl;
+}

--- a/index.html
+++ b/index.html
@@ -62,6 +62,10 @@
       position: relative;
       overflow: hidden;
       isolation: isolate;
+      cursor: pointer;
+      text-align: left;
+      color: inherit;
+      appearance: none;
     }
 
     .cta-card::after {
@@ -157,7 +161,7 @@
   <main>
     <section class="cta-section" aria-label="Navigasi utama">
       <div class="container cta-grid">
-        <a class="cta-card" href="form.html" aria-label="Buka halaman Form Input Upah harian">
+        <button type="button" class="cta-card" data-action="open-new-form" aria-label="Buka formulir input upah harian di tab ini">
           <span class="cta-icon" aria-hidden="true">
             <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
               <rect x="6" y="10" width="36" height="28" rx="6" stroke="currentColor" stroke-width="2.5"/>
@@ -175,7 +179,7 @@
               <path d="M11 5l5 5-5 5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
           </span>
-        </a>
+        </button>
         <a class="cta-card" href="rekap.html" aria-label="Buka halaman Rekap periode pembayaran">
           <span class="cta-icon" aria-hidden="true">
             <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -199,5 +203,16 @@
       </div>
     </section>
   </main>
+  <script type="module">
+    import { openNewFormAutoClose } from "./assets/js/nav.js";
+
+    const newFormButton = document.querySelector('[data-action="open-new-form"]');
+
+    if (newFormButton) {
+      newFormButton.addEventListener("click", () => {
+        openNewFormAutoClose();
+      });
+    }
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a navigation helper module that tracks form sessions in localStorage and builds the auto-close URL
- switch the “Input Upah” CTA to a script-driven button that navigates with the helper and updates its accessibility label

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68e148baa3688333a9ccf1fa8662d0a0