### PR TITLE
Refine rekap layout with shared design system styles

### DIFF
--- a/rekap.html
+++ b/rekap.html
@@ -1,44 +1,36 @@
 <!DOCTYPE html><html lang="id"><head>
 <meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>Rekap Periode — Total Bayar Per Periode</title>
-<style>
-  :root { --bg:#0b1020; --card:#111936; --ink:#e8ecf1; --muted:#a7b1c5; --line:#253066; --hi:#5ac8fa; }
-  *{box-sizing:border-box} body{margin:0;background:linear-gradient(180deg,#0b1020,#0e1634);color:var(--ink);font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,"Helvetica Neue",Arial,sans-serif}
-  header{padding:18px 14px;border-bottom:1px solid #1a2350} h1{margin:0;font-size:20px} .sub{color:var(--muted);font-size:13px;margin-top:6px}
-  main{max-width:820px;margin:18px auto;padding:0 14px 48px} .card{background:var(--card);border:1px solid var(--line);border-radius:14px;box-shadow:0 10px 30px rgba(0,0,0,.25);margin-bottom:12px}
-  .section{padding:14px} .row{display:flex;gap:10px;align-items:center;flex-wrap:wrap}
-  button{border-radius:10px;border:1px solid #2a3770;background:#0f1838;color:#e8ecf1;padding:10px 12px;cursor:pointer;font-weight:700}
-  .badge{display:inline-block;font-size:12px;padding:4px 8px;border-radius:999px;border:1px solid #2a3770;color:#a7b1c5}
-  .table-wrap{overflow:auto;border-top:1px solid #1f2750} table{width:100%;border-collapse:collapse}
-  th,td{padding:10px 12px;border-bottom:1px solid #1f2750;text-align:left;font-size:14px} th{position:sticky;top:0;background:#121a3f}
-  td.right,th.right{text-align:right} .empty{padding:20px;color:#a7b1c5;text-align:center} .sum{font-weight:800}
-</style></head><body>
-<header><h1>Rekap Periode</h1><div class="sub">Periode & Total Bayar Periode (tersimpan otomatis & saat klik <em>Simpan</em> di form).</div></header>
-<main>
-  <section class="card section">
-    <div class="row">
-      <button id="btnOpenForm">Buka Form (Auto-close)</button>
+<link rel="stylesheet" href="styles/system.css"/>
+<link rel="stylesheet" href="styles/pages.css"/></head><body>
+<div class="page-shell container">
+<header class="section-header"><h1>Rekap Periode</h1><div class="section-subtitle">Periode & Total Bayar Periode (tersimpan otomatis & saat klik <em>Simpan</em> di form).</div></header>
+<main class="page-content">
+  <section class="card">
+    <div class="action-bar">
+      <button id="btnOpenForm" class="btn btn-primary">Buka Form (Auto-close)</button>
       <span id="seqBadge" class="badge">Next: ?new=1</span>
-      <button id="btnResetSeq">Reset Nomor (?new=1)</button>
-      <button id="btnReload">Muat Ulang</button>
-      <select id="order"><option value="desc" selected>Urut Terbaru → Lama</option><option value="asc">Urut Lama → Terbaru</option></select>
-      <button id="btnExport">Ekspor CSV</button><input id="imp" type="file" accept=".csv,text/csv" style="display:none"/><button id="btnImport">Impor CSV</button>
+      <button id="btnResetSeq" class="btn btn-secondary">Reset Nomor (?new=1)</button>
+      <button id="btnReload" class="btn btn-secondary">Muat Ulang</button>
+      <select id="order" class="input-select"><option value="desc" selected>Urut Terbaru → Lama</option><option value="asc">Urut Lama → Terbaru</option></select>
+      <button id="btnExport" class="btn btn-secondary">Ekspor CSV</button><input id="imp" type="file" accept=".csv,text/csv" style="display:none"/><button id="btnImport" class="btn btn-secondary">Impor CSV</button>
       <span class="badge" id="counter">0 periode</span>
     </div>
   </section>
-  <section class="card"><div class="table-wrap">
-    <table><thead><tr>
+  <section class="card table-card"><div class="table-card__scroller">
+    <table class="table"><thead><tr>
   <th>Periode Mulai</th>
   <th>Periode Selesai</th>
   <th class="right">Total Bayar Periode</th>
   <th>Sumber</th>
   <th>Aksi</th>
 </tr></thead>
-      <tbody id="tbody"><tr class="empty"><td colspan="5">Belum ada data. Buka form, isi & tekan <b>Simpan</b>.</td></tr></tbody>
+      <tbody id="tbody"><tr class="empty-state"><td colspan="5">Belum ada data. Buka form, isi & tekan <b>Simpan</b>.</td></tr></tbody>
       <tfoot><tr><td colspan="2" class="right sum">GRAND TOTAL</td><td id="grand" class="right sum">Rp 0</td></tr></tfoot>
     </table></div>
   </section>
 </main>
+</div>
 <script>
   const KEY_HISTORY='upah20_period_history_v2', KEY_SEQ='upah20_new_sequence_counter';
   function load(){ try{return JSON.parse(localStorage.getItem(KEY_HISTORY))||[];}catch(_){return [];} }
@@ -48,7 +40,7 @@
   function refreshBadge(){ document.getElementById('seqBadge').textContent='Next: ?new='+getSeq(); }
   function render(){
     let arr=load(); const order=document.getElementById('order').value||'desc'; const tbody=document.getElementById('tbody'); tbody.innerHTML='';
-    if(!arr.length){ tbody.innerHTML='<tr class="empty"><td colspan="3">Belum ada data.</td></tr>'; document.getElementById('counter').textContent='0 periode'; document.getElementById('grand').textContent='Rp 0'; return; }
+    if(!arr.length){ tbody.innerHTML='<tr class="empty-state"><td colspan="5">Belum ada data. Buka form, isi & tekan <b>Simpan</b>.</td></tr>'; document.getElementById('counter').textContent='0 periode'; document.getElementById('grand').textContent='Rp 0'; return; }
     arr.sort((a,b)=> order==='desc'? b.periodeMulai.localeCompare(a.periodeMulai) : a.periodeMulai.localeCompare(b.periodeMulai));
     let grand=0; for(const r of arr){
       grand+=Number(r.sumTotal||0);
@@ -66,8 +58,8 @@
   <td>${r.periodeMulai||''}</td>
   <td>${r.periodeSelesai||''}</td>
   <td class="right">${rp(r.sumTotal||0)}</td>
-  <td><a href='${linkHref}' target='_blank' rel='noopener' data-source='${sourceAttr}' title='${sourceTitle}'>Buka Data</a></td>
-  <td><button class="btnDel" data-k="${key}" title="Hapus baris ini">Hapus</button></td>
+      <td><a href='${linkHref}' target='_blank' rel='noopener' data-source='${sourceAttr}' title='${sourceTitle}'>Buka Data</a></td>
+  <td><button class="btn btn-secondary btnDel" data-k="${key}" title="Hapus baris ini">Hapus</button></td>
 `; tbody.appendChild(tr); }
     document.getElementById('counter').textContent=arr.length+' periode'; document.getElementById('grand').textContent=rp(grand);
   }

--- a/styles/pages.css
+++ b/styles/pages.css
@@ -1,0 +1,217 @@
+.page-shell {
+  padding-block: var(--space-lg) var(--space-xl);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.section-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  padding-bottom: var(--space-md);
+  border-bottom: 1px solid var(--border);
+}
+
+.section-header h1 {
+  margin: 0;
+  font-size: clamp(1.75rem, 4vw, 2.25rem);
+  font-weight: 700;
+  letter-spacing: -0.015em;
+}
+
+.section-subtitle {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  max-width: 60ch;
+}
+
+.page-content {
+  display: grid;
+  gap: var(--space-lg);
+}
+
+.card {
+  background: var(--surface-elevated);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-lg);
+  padding: clamp(var(--space-md), 4vw, var(--space-lg));
+}
+
+.table-card {
+  padding: 0;
+  overflow: hidden;
+}
+
+.table-card__scroller {
+  overflow-x: auto;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  color: var(--text-secondary);
+  background: rgba(15, 23, 42, 0.5);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.action-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.65rem 1.1rem;
+  border-radius: var(--radius-md);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  border: 1px solid transparent;
+  cursor: pointer;
+  background: transparent;
+  color: var(--text-primary);
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+}
+
+.btn:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 3px;
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  border-color: rgba(249, 115, 22, 0.7);
+  color: var(--accent-contrast);
+  box-shadow: 0 18px 38px rgba(249, 115, 22, 0.35);
+}
+
+.btn-primary:hover {
+  box-shadow: 0 22px 44px rgba(249, 115, 22, 0.42);
+}
+
+.btn-secondary {
+  background: rgba(30, 41, 59, 0.7);
+  border-color: rgba(148, 163, 184, 0.35);
+}
+
+.btn-secondary:hover {
+  background: rgba(30, 41, 59, 0.9);
+  border-color: rgba(148, 163, 184, 0.55);
+}
+
+.input-select {
+  appearance: none;
+  padding: 0.65rem 2.5rem 0.65rem 0.9rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: var(--surface);
+  color: var(--text-primary);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  min-width: 15rem;
+  background-image: linear-gradient(45deg, transparent 50%, rgba(148, 163, 184, 0.7) 50%),
+                    linear-gradient(135deg, rgba(148, 163, 184, 0.7) 50%, transparent 50%);
+  background-position: calc(100% - 1.5rem) calc(50% - 2px), calc(100% - 1rem) calc(50% - 2px);
+  background-size: 0.6rem 0.6rem, 0.6rem 0.6rem;
+  background-repeat: no-repeat;
+}
+
+.input-select:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 3px;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 640px;
+}
+
+.table thead th {
+  text-align: left;
+  font-size: 0.75rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.75);
+  background: rgba(15, 23, 42, 0.85);
+  padding: 0.9rem 1rem;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  backdrop-filter: blur(8px);
+}
+
+.table tbody td {
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+  font-size: 0.95rem;
+}
+
+.table tbody tr:nth-child(odd) td {
+  background: rgba(15, 23, 42, 0.35);
+}
+
+.table tbody tr:hover td {
+  background: rgba(30, 41, 59, 0.55);
+}
+
+.table tfoot td {
+  padding: 1rem;
+  font-weight: 700;
+  border-top: 1px solid rgba(249, 115, 22, 0.25);
+  background: rgba(15, 23, 42, 0.65);
+}
+
+.table .right {
+  text-align: right;
+}
+
+.sum {
+  letter-spacing: 0.08em;
+}
+
+.empty-state td,
+.empty-state {
+  text-align: center;
+  padding: var(--space-lg);
+  color: var(--text-secondary);
+  font-weight: 500;
+  background: rgba(15, 23, 42, 0.4);
+}
+
+@media (max-width: 720px) {
+  .page-shell {
+    padding-block: var(--space-md) var(--space-lg);
+  }
+
+  .input-select {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .action-bar {
+    align-items: stretch;
+  }
+
+  .btn,
+  .badge {
+    width: 100%;
+    justify-content: center;
+  }
+}


### PR DESCRIPTION
## Summary
- link the rekap page to the shared system stylesheet and remove the legacy inline styles
- introduce a reusable pages.css with layout, card, table, badge, button, and empty state utilities
- restyle rekap.html to use the shared classes for the action bar, table card, zebra rows, and empty-state message

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e14d64892483338dd74f5d5b6d65dd