### PR TITLE
Add Netlify save proxy and update snapshot export

### DIFF
--- a/form.html
+++ b/form.html
@@ -1864,19 +1864,43 @@ const upahPokok = hari * rate;
         rowsCount: Array.isArray(rows) ? rows.length : 0,
       };
 
-      const response = await fetch('/.netlify/functions/snapshot', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ html: htmlDocument, meta })
-      });
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 15000);
 
-      const result = await response.json().catch(() => ({}));
-      if (!response.ok || !result || result.ok !== true) {
-        const errorMessage = result && result.error ? result.error : `HTTP ${response.status}`;
+      let response;
+      try {
+        response = await fetch('/api/save', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ html: htmlDocument, meta }),
+          mode: 'cors',
+          signal: controller.signal
+        });
+      } catch (fetchError) {
+        throw new Error(fetchError && fetchError.message ? fetchError.message : 'Gagal menghubungi layanan penyimpanan');
+      } finally {
+        clearTimeout(timeoutId);
+      }
+
+      const rawBody = await response.text();
+      let result = {};
+      if (rawBody) {
+        try {
+          result = JSON.parse(rawBody);
+        } catch (parseError) {
+          result = { message: rawBody };
+        }
+      }
+
+      const responseOk = response.ok && (result.ok === undefined || result.ok === true);
+      if (!responseOk) {
+        const statusText = response.statusText ? ` ${response.statusText}` : '';
+        const upstreamMessage = result && (result.error || result.message);
+        const errorMessage = upstreamMessage || `HTTP ${response.status}${statusText}`;
         throw new Error(errorMessage);
       }
 
-      return { ok: true, key: result.key, createdAt: result.createdAt };
+      return { ok: true, ...result };
     }catch(err){
       if (htmlDocument) {
         try {

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,12 @@
+[build]
+  command = ""
+  publish = "."
+
 [functions]
-node_bundler = "esbuild"
-external_node_modules = ["@netlify/blobs"]
+  node_bundler = "esbuild"
+  external_node_modules = ["@netlify/blobs"]
+
+[[redirects]]
+  from = "/api/save"
+  to = "/.netlify/functions/save"
+  status = 200

--- a/netlify/functions/save.js
+++ b/netlify/functions/save.js
@@ -1,0 +1,103 @@
+const CORS_HEADERS = {
+  "access-control-allow-origin": "*",
+  "access-control-allow-methods": "POST,OPTIONS",
+  "access-control-allow-headers": "content-type",
+};
+
+const JSON_HEADERS = {
+  "content-type": "application/json; charset=utf-8",
+  "cache-control": "no-store",
+};
+
+function withCors(init = {}) {
+  const headers = new Headers(init.headers || {});
+  for (const [key, value] of Object.entries(CORS_HEADERS)) {
+    headers.set(key, value);
+  }
+  return new Headers(headers);
+}
+
+function jsonResponse(body, init = {}) {
+  const headers = withCors({
+    headers: {
+      ...JSON_HEADERS,
+      ...(init.headers || {}),
+    },
+  });
+
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers,
+  });
+}
+
+export default async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, {
+      status: 204,
+      headers: withCors(),
+    });
+  }
+
+  if (req.method !== "POST") {
+    return jsonResponse({ ok: false, error: "Method Not Allowed" }, { status: 405 });
+  }
+
+  const targetUrl = process.env.SAVE_TARGET_URL;
+  if (!targetUrl) {
+    console.error("Missing SAVE_TARGET_URL environment variable");
+    return jsonResponse({ ok: false, error: "SAVE_TARGET_URL is not configured" }, { status: 500 });
+  }
+
+  let payload;
+  try {
+    payload = await req.json();
+  } catch (error) {
+    return jsonResponse({ ok: false, error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  let upstreamResponse;
+  try {
+    upstreamResponse = await fetch(targetUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload ?? {}),
+      signal: AbortSignal.timeout(15000),
+    });
+  } catch (error) {
+    console.error("Failed to reach SAVE_TARGET_URL", error);
+    return jsonResponse({ ok: false, error: "Failed to reach upstream service" }, { status: 504 });
+  }
+
+  let parsedBody = null;
+  let rawBody = "";
+  try {
+    rawBody = await upstreamResponse.text();
+  } catch (error) {
+    console.error("Failed to read upstream response body", error);
+  }
+
+  if (rawBody) {
+    try {
+      parsedBody = JSON.parse(rawBody);
+    } catch (error) {
+      parsedBody = { message: rawBody };
+    }
+  }
+
+  const responseBody = parsedBody ?? {};
+  const status = upstreamResponse.status || 200;
+
+  if (!upstreamResponse.ok) {
+    const errorMessage =
+      (responseBody && (responseBody.error || responseBody.message)) ||
+      upstreamResponse.statusText ||
+      `HTTP ${status}`;
+    return jsonResponse({ ok: false, error: errorMessage, details: responseBody }, { status });
+  }
+
+  return new Response(JSON.stringify(responseBody), {
+    status,
+    headers: withCors({ headers: JSON_HEADERS }),
+  });
+};


### PR DESCRIPTION
## Summary
- add a Netlify Function that proxies save requests to the configured SAVE_TARGET_URL with CORS support and timeout handling
- update netlify.toml to define the build settings and redirect /api/save to the new function
- adjust the HTML snapshot exporter to call the new API endpoint with CORS mode, a 15s abort controller, and clearer error messages

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1d0a0313883339a7b71e5a2930ab8