### PR TITLE
Improve save function CORS and error handling

### DIFF
--- a/netlify/functions/save.js
+++ b/netlify/functions/save.js
@@ -1,7 +1,19 @@
+const NORMALIZED_ENV_ORIGINS = [
+  process.env.ALLOWED_ORIGIN,
+  process.env.DEPLOY_URL,
+  process.env.DEPLOY_PRIME_URL,
+  process.env.URL,
+  process.env.NETLIFY_DEV_SERVER_URL,
+]
+  .map((value) => (typeof value === "string" ? value.trim() : ""))
+  .filter(Boolean);
+
+const ALLOWED_ORIGIN = NORMALIZED_ENV_ORIGINS[0] || "";
+
 const CORS_HEADERS = {
-  "access-control-allow-origin": "*",
-  "access-control-allow-methods": "POST,OPTIONS",
-  "access-control-allow-headers": "content-type",
+  "Access-Control-Allow-Methods": "POST,OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  Vary: "Origin",
 };
 
 const JSON_HEADERS = {
@@ -11,10 +23,17 @@ const JSON_HEADERS = {
 
 function withCors(init = {}) {
   const headers = new Headers(init.headers || {});
-  for (const [key, value] of Object.entries(CORS_HEADERS)) {
-    headers.set(key, value);
+  if (ALLOWED_ORIGIN) {
+    headers.set("Access-Control-Allow-Origin", ALLOWED_ORIGIN);
   }
-  return new Headers(headers);
+
+  for (const [key, value] of Object.entries(CORS_HEADERS)) {
+    if (!headers.has(key)) {
+      headers.set(key, value);
+    }
+  }
+
+  return headers;
 }
 
 function jsonResponse(body, init = {}) {
@@ -31,7 +50,34 @@ function jsonResponse(body, init = {}) {
   });
 }
 
+function isOriginAllowed(origin) {
+  if (!origin) {
+    return true;
+  }
+
+  if (!ALLOWED_ORIGIN) {
+    return false;
+  }
+
+  return origin === ALLOWED_ORIGIN;
+}
+
+function buildErrorBody(error, details) {
+  return {
+    ok: false,
+    error,
+    ...(details === undefined ? {} : { details }),
+  };
+}
+
 export default async (req) => {
+  const requestOrigin = req.headers.get("origin");
+
+  if (!isOriginAllowed(requestOrigin)) {
+    console.error("save-function: blocked origin", { origin: requestOrigin });
+    return jsonResponse(buildErrorBody("Origin Not Allowed"), { status: 403 });
+  }
+
   if (req.method === "OPTIONS") {
     return new Response(null, {
       status: 204,
@@ -40,21 +86,52 @@ export default async (req) => {
   }
 
   if (req.method !== "POST") {
-    return jsonResponse({ ok: false, error: "Method Not Allowed" }, { status: 405 });
+    return jsonResponse(buildErrorBody("Method Not Allowed"), { status: 405 });
   }
 
   const targetUrl = process.env.SAVE_TARGET_URL;
   if (!targetUrl) {
     console.error("Missing SAVE_TARGET_URL environment variable");
-    return jsonResponse({ ok: false, error: "SAVE_TARGET_URL is not configured" }, { status: 500 });
+    return jsonResponse(buildErrorBody("SAVE_TARGET_URL is not configured"), { status: 500 });
   }
 
   let payload;
   try {
     payload = await req.json();
   } catch (error) {
-    return jsonResponse({ ok: false, error: "Invalid JSON body" }, { status: 400 });
+    console.error("save-function: failed to parse JSON body", {
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return jsonResponse(
+      buildErrorBody("Invalid JSON body", {
+        message: error instanceof Error ? error.message : String(error),
+      }),
+      { status: 400 },
+    );
   }
+
+  const isPayloadValid =
+    payload &&
+    typeof payload === "object" &&
+    typeof payload.html === "string" &&
+    payload.html.trim().length > 0 &&
+    payload.meta &&
+    typeof payload.meta === "object";
+
+  if (!isPayloadValid) {
+    console.error("save-function: invalid payload", {
+      hasHtml: Boolean(payload && typeof payload.html === "string"),
+      hasMeta: Boolean(payload && typeof payload.meta === "object"),
+    });
+    return jsonResponse(buildErrorBody("Invalid payload", { field: "html/meta" }), {
+      status: 400,
+    });
+  }
+
+  console.info("save-function: received payload", {
+    meta: payload.meta,
+    htmlLength: payload.html.length,
+  });
 
   let upstreamResponse;
   try {
@@ -65,8 +142,15 @@ export default async (req) => {
       signal: AbortSignal.timeout(15000),
     });
   } catch (error) {
-    console.error("Failed to reach SAVE_TARGET_URL", error);
-    return jsonResponse({ ok: false, error: "Failed to reach upstream service" }, { status: 504 });
+    console.error("save-function: failed to reach SAVE_TARGET_URL", {
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return jsonResponse(
+      buildErrorBody("Failed to reach upstream service", {
+        message: error instanceof Error ? error.message : String(error),
+      }),
+      { status: /timeout/i.test(String(error)) ? 504 : 502 },
+    );
   }
 
   let parsedBody = null;
@@ -74,7 +158,9 @@ export default async (req) => {
   try {
     rawBody = await upstreamResponse.text();
   } catch (error) {
-    console.error("Failed to read upstream response body", error);
+    console.error("save-function: failed to read upstream response body", {
+      message: error instanceof Error ? error.message : String(error),
+    });
   }
 
   if (rawBody) {
@@ -88,12 +174,18 @@ export default async (req) => {
   const responseBody = parsedBody ?? {};
   const status = upstreamResponse.status || 200;
 
+  console.info("save-function: upstream response", {
+    status,
+    ok: upstreamResponse.ok,
+    body: responseBody,
+  });
+
   if (!upstreamResponse.ok) {
     const errorMessage =
       (responseBody && (responseBody.error || responseBody.message)) ||
       upstreamResponse.statusText ||
       `HTTP ${status}`;
-    return jsonResponse({ ok: false, error: errorMessage, details: responseBody }, { status });
+    return jsonResponse(buildErrorBody(errorMessage, responseBody), { status });
   }
 
   return new Response(JSON.stringify(responseBody), {


### PR DESCRIPTION
## Summary
- restrict the save function CORS policy to the configured origin with updated headers
- add structured logging and stricter payload validation before calling the upstream service
- enhance error handling for JSON parsing, invalid payloads, and upstream failures with detailed responses

## Testing
- ⚠️ `npx netlify dev --port 9999` *(fails: npm registry access returns 403 in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e1e9261d0483338a4ba5fcfc5a1fd7