### PR TITLE
Add configurable backend module and Netlify API fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,76 +1,101 @@
 # Upah Tukang Netlify Worker
 
 ## Arsitektur Ringkas
-- **Formulir klien** (`form.html`) mengumpulkan data dan merender HTML snapshot.
-- **Netlify Function `save`** (`/.netlify/functions/save`) menerima payload `{ html, meta }`, melakukan validasi CORS berdasar `ALLOWED_ORIGIN`, lalu meneruskan payload ke layanan hulu yang ditentukan oleh `SAVE_TARGET_URL` (mis. Google Apps Script) dengan timeout 15 detik.
-- **Netlify Functions `snapshot` & `state`** menyimpan/mengambil HTML snapshot dan state JSON pada Netlify Blobs Store (`upah20`). Snapshot yang tersimpan bisa diambil kembali via `/.netlify/functions/snapshot?key=...`.
-- **Target eksternal** (Google Apps Script atau webhook lain) menerima payload dari fungsi `save` untuk persisten data (spreadsheet, database, dll.).
+- **Konfigurasi klien** (`assets/js/config.js`) membaca `window.__ENV__` atau `<script id="env-config">` bertipe JSON untuk memperoleh `DATA_BACKEND`, `WEBAPP_URL`, `API_KEY`, dan `SHEET_ID`. Modul ini menyiapkan helper `createApiClient()` yang dipakai seluruh interaksi data di `form.html`.
+- **Formulir klien** (`form.html`) merender kalkulator, men-generate snapshot HTML, lalu memilih target API (`/api/*` Netlify Function atau Google Apps Script) lewat helper konfigurasi.
+- **Netlify Function fallback** (`netlify/functions/api.js`) menangani seluruh rute `GET/POST/PUT/DELETE /api/(list|item|save|update|remove)` dan menyimpan data ke Netlify Blobs Store (`upah20`). Fungsi ini juga menangani preflight `OPTIONS` untuk CORS.
+- **Netlify Functions `snapshot` & `state`** mempertahankan arsip HTML dan state JSON sehingga snapshot lama bisa diunduh ulang melalui `/.netlify/functions/snapshot?key=...`.
 
-## Konfigurasi Environment Netlify
-Atur variabel-variabel berikut pada dashboard Netlify (`Site settings → Build & deploy → Environment`):
+## Variabel Lingkungan
+Atur variabel di dashboard Netlify (`Site settings → Build & deploy → Environment`) atau pada file `.env` lokal ketika menjalankan `netlify dev`.
 
-| Variabel | Deskripsi |
-| --- | --- |
-| `SAVE_TARGET_URL` | Endpoint HTTPS tujuan (mis. URL Google Apps Script) yang menerima payload dari fungsi `save`. Wajib ada. |
-| `ALLOWED_ORIGIN` | Origin yang diizinkan mengakses fungsi `save` (mis. `https://example.netlify.app`). Digunakan untuk header CORS. |
-| `NETLIFY_BLOBS_CONTEXT` *(otomatis)* | Disediakan Netlify saat fungsi berjalan di produksi. Tidak perlu diubah manual. |
+| Variabel | Wajib? | Deskripsi |
+| --- | --- | --- |
+| `DATA_BACKEND` | Opsional (default `NETLIFY_FN`) | Pilihan backend data (`NETLIFY_FN` untuk fallback Netlify, `APPS_SCRIPT` untuk Google Apps Script). |
+| `WEBAPP_URL` | Wajib jika `DATA_BACKEND=APPS_SCRIPT` | URL Web App Apps Script (`https://script.google.com/macros/s/…/exec`). Untuk backend Netlify boleh dikosongkan (default `/api`). |
+| `API_KEY` | Opsional | Diteruskan sebagai header `X-API-KEY` ke backend (berguna bila Apps Script mengecek token). |
+| `SHEET_ID` | Opsional | Diteruskan sebagai header `X-SHEET-ID` (mis. agar Apps Script tahu spreadsheet mana yang harus dipakai). |
+| `ALLOWED_ORIGIN` | Disarankan | Origin yang diizinkan mengakses fungsi Netlify (`https://contoh.netlify.app`). Dipakai oleh validasi CORS pada `netlify/functions/api.js`. |
 
-> **Catatan:** Selama preview/production deploy Netlify akan menyuntikkan `DEPLOY_URL`, `DEPLOY_PRIME_URL`, `URL`, dan `NETLIFY_DEV_SERVER_URL`. Fungsi `save` secara otomatis menerima origin-origin ini untuk fallback, tetapi `ALLOWED_ORIGIN` tetap direkomendasikan untuk eksplisit.
+> **Catatan:** Netlify otomatis menambahkan `DEPLOY_URL`, `DEPLOY_PRIME_URL`, `URL`, dan `NETLIFY_DEV_SERVER_URL`. Fungsi fallback akan menerima origin-origin ini sebagai fallback jika `ALLOWED_ORIGIN` kosong.
 
-Untuk pengembangan lokal, buat berkas `.env` (tidak di-commit) di akar repo:
+### Mengekspor ENV ke Front-End
+`assets/js/config.js` akan mencari konfigurasi di salah satu sumber berikut:
 
-```env
-SAVE_TARGET_URL="https://script.google.com/macros/s/XXXX/exec"
-ALLOWED_ORIGIN="http://localhost:8888"
-```
+1. Objek global `window.__ENV__`, misalnya:
+   ```html
+   <script>
+     window.__ENV__ = {
+       DATA_BACKEND: 'APPS_SCRIPT',
+       WEBAPP_URL: 'https://script.google.com/macros/s/XXXX/exec',
+       API_KEY: 'sekali_pakai',
+       SHEET_ID: '123abc'
+     };
+   </script>
+   ```
+2. Elemen `<script id="env-config" type="application/json">` atau `<script id="__ENV__" type="application/json">` yang berisi JSON:
+   ```html
+   <script id="env-config" type="application/json">
+     { "DATA_BACKEND": "NETLIFY_FN" }
+   </script>
+   ```
 
-Kemudian jalankan `netlify dev` agar variabel dimuat.
+Jika tidak ada sumber di atas, aplikasi akan menggunakan backend Netlify (`/api/*`).
+
+## Integrasi Google Apps Script
+1. **Buat proyek Apps Script baru** yang terhubung dengan Google Sheet tujuan.
+2. **Implementasikan `doGet/doPost/doPut/doDelete`**. Bacalah body JSON (`e.postData.contents`), perhatikan query `?new=1`, dan gunakan `ContentService.createTextOutput(JSON.stringify(payload))` dengan `setMimeType(ContentService.MimeType.JSON)` untuk merespons.
+   - Tambahkan header CORS pada setiap respons, misalnya `output.setHeader('Access-Control-Allow-Origin', 'https://contoh.netlify.app')`, `output.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-API-KEY, X-SHEET-ID')`, dan `output.setHeader('Access-Control-Allow-Methods', 'GET,POST,PUT,DELETE,OPTIONS')`.
+   - Sediakan handler `doOptions` yang mengembalikan status 204 untuk melayani preflight browser.
+3. **Deploy sebagai Web App** (`Deploy → Manage deployments → Web app`). Pilih *Execute as Me* dan *Who has access* → *Anyone with the link*. Catat URL `https://script.google.com/macros/s/.../exec` dan masukkan ke `WEBAPP_URL`.
+4. **Isi ENV Netlify atau script inline** sesuai tabel di atas, lalu set `DATA_BACKEND=APPS_SCRIPT` agar front-end mengirim request ke Apps Script.
 
 ## Menjalankan Secara Lokal
 1. **Instal dependensi** (sekali saja):
    ```bash
    npm install
    ```
-2. **Jalankan dev server Netlify** (membuka situs statis + fungsi):
+2. **Jalankan Netlify Dev** (menyajikan situs statis + fungsi):
    ```bash
    netlify dev
    ```
-   - Aplikasi statis tersedia di `http://localhost:8888` secara default.
-   - Fungsi dapat diakses via `http://localhost:8888/.netlify/functions/<nama>`.
-3. **Pengujian manual:**
+   - Situs tersedia di `http://localhost:8888`.
+   - Endpoint fallback tersedia di `http://localhost:8888/api/<route>` (mis. `POST /api/save`).
+3. **Pengujian manual**:
    - **Skenario sukses**
      1. Buka `http://localhost:8888/form.html`.
-     2. Isi data minimal hingga tombol simpan aktif.
-     3. Kirim formulir dan pastikan respons fungsi `save` menampilkan `{"ok":true,...}` di console devtools/network.
-     4. Pastikan Google Apps Script (atau target lain) menerima dan menyimpan payload.
+     2. Isi data hingga tombol simpan aktif.
+     3. Tekan *Simpan* dan pastikan Network devtools memperlihatkan respons `{"ok":true,...}` dari `/api/save` atau URL Apps Script.
+     4. Verifikasi data tersimpan di Netlify Blobs (lihat log fungsi) atau di Google Sheets.
    - **Skenario gagal**
-     1. Ubah `SAVE_TARGET_URL` di `.env` ke URL yang salah, atau matikan jaringan.
-     2. Ulangi submit formulir dan pastikan fungsi `save` menampilkan pesan error (HTTP 502/504) dan UI menampilkan notifikasi gagal.
-     3. Periksa bahwa log Netlify memuat pesan `failed to reach SAVE_TARGET_URL`.
-4. **Memantau log fungsi lokal**: CLI akan menampilkan `console.info/error` secara realtime di terminal `netlify dev`. Untuk log terpisah:
+     1. Ganti `WEBAPP_URL` dengan URL yang salah atau matikan koneksi internet.
+     2. Simpan ulang dan pastikan UI menampilkan notifikasi gagal, sedangkan log fungsi menunjukkan error HTTP.
+4. **Memantau log fungsi lokal**: jalankan
    ```bash
-   netlify functions:serve save snapshot state
+   netlify functions:serve api snapshot state
    ```
+   untuk melihat log `console.*` dari tiap fungsi.
 
 ## Monitoring & Logging Produksi
-- Gunakan `netlify functions:tail --name save` untuk streaming log dari deploy aktif.
-- Dashboard Netlify → **Functions** menampilkan statistik & log historis.
-- Untuk men-debug request tertentu, tambahkan metadata di payload `meta` agar mudah dilacak di log target eksternal.
+- Gunakan `netlify functions:tail --name api` untuk streaming log fungsi fallback.
+- Dashboard Netlify → **Functions** menampilkan statistik dan log historis untuk `api`, `snapshot`, dan `state`.
+- Tambahkan metadata ke payload `meta` (mis. periode, user) agar mudah dilacak di log backend.
 
 ## Checklist Pasca-Deploy
-- [ ] Deploy berhasil (`Production deploy` berstatus sukses di Netlify).
-- [ ] Variabel `SAVE_TARGET_URL` & `ALLOWED_ORIGIN` terisi dan cocok dengan domain formulir.
-- [ ] Lakukan submit sampel dari situs produksi dan pastikan respons `{"ok":true}`.
-- [ ] Catat nilai `key` dari respons `/.netlify/functions/snapshot` lalu akses `/.netlify/functions/snapshot?key=<key>` untuk memastikan HTML tersimpan.
-- [ ] Verifikasi target eksternal (Google Sheets/dll.) menerima snapshot/meta terbaru.
+- [ ] Deploy produksi sukses di Netlify.
+- [ ] `DATA_BACKEND`, `WEBAPP_URL`, `ALLOWED_ORIGIN`, dan token lain terisi sesuai lingkungan.
+- [ ] Submit sampel dari situs produksi dan pastikan respons backend `{"ok":true}`.
+- [ ] Catat `snapshotKey` dari respons lalu akses `/.netlify/functions/snapshot?key=<key>` untuk memastikan HTML tersimpan.
+- [ ] Jika memakai Apps Script, konfirmasi spreadsheet menerima baris baru/pembaruan.
 
 ## Troubleshooting Umum
-- **CORS Error (`Origin Not Allowed`)**: pastikan `ALLOWED_ORIGIN` sesuai dengan domain formulir (termasuk protokol). Deploy ulang setelah mengubah environment variable.
-- **Timeout / 502 / 504 dari fungsi `save`**: cek apakah `SAVE_TARGET_URL` dapat diakses publik dan merespons < 15 detik. Untuk proses lama, pertimbangkan queue atau worker terpisah.
-- **Offline / jaringan lokal terputus saat dev**: `netlify dev` akan gagal menghubungi target eksternal. Gunakan mock server lokal (`npx http-echo-server`) atau set `SAVE_TARGET_URL` ke endpoint yang tersedia offline.
-- **Snapshot tidak ditemukan (`404`)**: pastikan key yang digunakan benar dan deploy memiliki akses Netlify Blobs. Jalankan ulang deploy jika `NETLIFY_BLOBS_CONTEXT` belum terset.
+- **CORS Error (`Origin Not Allowed`)**: cek `ALLOWED_ORIGIN` pada Netlify ataupun header yang dikembalikan Apps Script.
+- **HTTP 502/504**: backend eksternal lambat/timeout. Periksa log `netlify functions:tail --name api` atau log Apps Script.
+- **Data tidak masuk ke Sheet**: validasi `API_KEY` / `SHEET_ID` pada Apps Script dan pastikan query `?new=1` serta `body.key` diproses.
+- **Snapshot tidak ditemukan (`404`)**: kunci salah atau store Netlify Blobs belum terset. Deploy ulang dan cek bahwa fungsi `api` memiliki akses `NETLIFY_BLOBS_CONTEXT`.
 
 ## Referensi Tambahan
 - Netlify CLI: <https://docs.netlify.com/cli/get-started/>
 - Netlify Functions: <https://docs.netlify.com/functions/overview/>
 - Netlify Blobs: <https://docs.netlify.com/blobs/overview/>
+- Google Apps Script Web Apps: <https://developers.google.com/apps-script/guides/web>

--- a/assets/js/config.js
+++ b/assets/js/config.js
@@ -1,0 +1,252 @@
+const ENV_KEYS = ["DATA_BACKEND", "WEBAPP_URL", "API_KEY", "SHEET_ID"];
+
+function normalizeValue(value) {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length ? trimmed : undefined;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return value;
+}
+
+function readGlobalEnv() {
+  if (typeof window === "undefined") return {};
+  const source = window.__ENV__;
+  if (source && typeof source === "object") {
+    return { ...source };
+  }
+  return {};
+}
+
+function parseScriptJSON(text) {
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    console.warn("config: gagal parsing JSON inline", error);
+    return null;
+  }
+}
+
+function readInlineEnv() {
+  if (typeof document === "undefined") return {};
+  const scripts = Array.from(
+    document.querySelectorAll(
+      "script[data-env], script[type='application/json'][id='__ENV__'], script[id='env-config']",
+    ),
+  );
+
+  for (const script of scripts) {
+    const text = script.textContent || script.innerText || "";
+    const dataAttr = script.getAttribute("data-env") || script.getAttribute("data-inline-env");
+
+    if (script.type === "application/json" || dataAttr === "json") {
+      const parsed = parseScriptJSON(text.trim());
+      if (parsed && typeof parsed === "object") {
+        return parsed;
+      }
+      continue;
+    }
+
+    const match = text.match(/__ENV__\s*=\s*({[\s\S]*?})\s*;?\s*$/m);
+    if (match) {
+      const parsed = parseScriptJSON(match[1]);
+      if (parsed && typeof parsed === "object") {
+        return parsed;
+      }
+    }
+  }
+
+  return {};
+}
+
+function mergeEnv(...sources) {
+  const merged = {};
+  sources
+    .filter((source) => source && typeof source === "object")
+    .forEach((source) => {
+      ENV_KEYS.forEach((key) => {
+        if (Object.prototype.hasOwnProperty.call(source, key)) {
+          merged[key] = source[key];
+        }
+      });
+    });
+  return merged;
+}
+
+function resolveBackend(value) {
+  const normalized = typeof value === "string" ? value.trim().toUpperCase() : "";
+  if (normalized === "APPS_SCRIPT") return "APPS_SCRIPT";
+  if (normalized === "NETLIFY_FN") return "NETLIFY_FN";
+  return normalized || "NETLIFY_FN";
+}
+
+let cachedConfig = null;
+
+function computeConfig() {
+  const sources = [readGlobalEnv(), readInlineEnv()];
+  const merged = mergeEnv(...sources);
+  const normalized = {};
+
+  ENV_KEYS.forEach((key) => {
+    normalized[key] = normalizeValue(merged[key]);
+  });
+
+  const backend = resolveBackend(normalized.DATA_BACKEND);
+
+  return {
+    DATA_BACKEND: backend,
+    WEBAPP_URL: normalized.WEBAPP_URL,
+    API_KEY: normalized.API_KEY,
+    SHEET_ID: normalized.SHEET_ID,
+  };
+}
+
+export function getEnvConfig({ forceReload = false } = {}) {
+  if (!cachedConfig || forceReload) {
+    cachedConfig = computeConfig();
+  }
+  return { ...cachedConfig };
+}
+
+function ensureOrigin() {
+  if (typeof window !== "undefined" && window.location) {
+    return window.location.origin;
+  }
+  return "http://localhost";
+}
+
+function toQueryValue(value) {
+  if (value === undefined || value === null) return null;
+  if (typeof value === "boolean") return value ? "1" : "0";
+  return String(value);
+}
+
+function mergePath(basePath, endpoint) {
+  const base = (basePath || "/").replace(/\/+$/, "");
+  const child = (endpoint || "").replace(/^\/+/, "");
+  if (!child) return base || "/";
+  if (!base || base === "/") return `/${child}`;
+  return `${base}/${child}`;
+}
+
+export function createApiClient(overrides = {}) {
+  const env = { ...getEnvConfig(), ...(overrides || {}) };
+  const backend = resolveBackend(env.DATA_BACKEND);
+
+  const defaultHeaders = new Headers();
+  defaultHeaders.set("Accept", "application/json, text/plain, */*");
+
+  if (backend === "APPS_SCRIPT" || backend === "NETLIFY_FN") {
+    defaultHeaders.set("Content-Type", "application/json; charset=utf-8");
+  }
+  defaultHeaders.set("Cache-Control", "no-store");
+
+  if (env.API_KEY) {
+    defaultHeaders.set("X-API-KEY", env.API_KEY);
+  }
+  if (env.SHEET_ID) {
+    defaultHeaders.set("X-SHEET-ID", env.SHEET_ID);
+  }
+
+  const baseUrl = env.WEBAPP_URL && typeof env.WEBAPP_URL === "string" ? env.WEBAPP_URL.trim() : "";
+
+  function buildUrl(endpoint, query) {
+    if (backend === "APPS_SCRIPT") {
+      if (!baseUrl) {
+        throw new Error("WEBAPP_URL wajib diisi untuk backend Apps Script");
+      }
+      const normalizedBase = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+      const url = new URL(endpoint ? endpoint.replace(/^\/+/, "") : "", normalizedBase);
+      if (query && typeof query === "object") {
+        Object.entries(query).forEach(([key, value]) => {
+          const normalizedValue = toQueryValue(value);
+          if (normalizedValue !== null) {
+            url.searchParams.set(key, normalizedValue);
+          }
+        });
+      }
+      return url.toString();
+    }
+
+    const origin = ensureOrigin();
+    const basePath = baseUrl ? baseUrl : "/api";
+    const baseAbsolute = new URL(basePath, origin);
+    const finalPath = mergePath(baseAbsolute.pathname, endpoint);
+    baseAbsolute.pathname = finalPath;
+
+    if (query && typeof query === "object") {
+      Object.entries(query).forEach(([key, value]) => {
+        const normalizedValue = toQueryValue(value);
+        if (normalizedValue !== null) {
+          baseAbsolute.searchParams.set(key, normalizedValue);
+        }
+      });
+    }
+
+    return baseAbsolute.toString();
+  }
+
+  function createRequest(endpoint, options = {}) {
+    const method = (options.method || "GET").toUpperCase();
+    let urlString;
+
+    try {
+      urlString = buildUrl(endpoint, options.query || null);
+    } catch (error) {
+      throw error;
+    }
+
+    const headers = new Headers(defaultHeaders);
+    if (options.headers && typeof options.headers === "object") {
+      Object.entries(options.headers).forEach(([key, value]) => {
+        if (value !== undefined && value !== null && value !== "") {
+          headers.set(key, value);
+        }
+      });
+    }
+
+    const init = {
+      method,
+      headers: Object.fromEntries(headers.entries()),
+    };
+
+    if (options.body !== undefined && options.body !== null) {
+      init.body = typeof options.body === "string" ? options.body : JSON.stringify(options.body);
+    } else if (method === "GET" || method === "HEAD") {
+      const hdrs = new Headers(init.headers);
+      if (hdrs.get("Content-Type")) {
+        hdrs.delete("Content-Type");
+        init.headers = Object.fromEntries(hdrs.entries());
+      }
+    }
+
+    if (backend === "APPS_SCRIPT") {
+      init.mode = "cors";
+    } else if (backend === "NETLIFY_FN") {
+      init.mode = "same-origin";
+    }
+
+    if (options.credentials) {
+      init.credentials = options.credentials;
+    }
+
+    return { url: urlString, init };
+  }
+
+  return {
+    backend,
+    env,
+    createRequest,
+  };
+}
+
+export default {
+  getEnvConfig,
+  createApiClient,
+};

--- a/form.html
+++ b/form.html
@@ -989,6 +989,33 @@ const defaultRumahList = baseRumah
   const displayDayOrder = [6,0,1,2,3,4,5];
   const displayDayKeys = displayDayOrder.map(i => dayKeys[i]);
 
+  let apiClientInstance = null;
+  let apiClientLoader = null;
+  let apiClientLoadError = null;
+
+  function ensureApiClient(){
+    if (apiClientInstance) return Promise.resolve(apiClientInstance);
+    if (apiClientLoadError) return Promise.reject(apiClientLoadError);
+    if (!apiClientLoader){
+      apiClientLoader = import('./assets/js/config.js')
+        .then((module) => {
+          if (!module || typeof module.createApiClient !== 'function'){
+            throw new Error('Modul konfigurasi API tidak tersedia');
+          }
+          const client = module.createApiClient();
+          apiClientInstance = client;
+          return client;
+        })
+        .catch((err) => {
+          const error = err instanceof Error ? err : new Error(String(err));
+          console.error('Gagal memuat konfigurasi backend', error);
+          apiClientLoadError = error;
+          throw error;
+        });
+    }
+    return apiClientLoader;
+  }
+
   const snapshotData = (typeof window !== 'undefined' && window.__UPAH_DATA__) ? window.__UPAH_DATA__ : null;
   const snapshotThreshold = snapshotData && snapshotData.allowanceThreshold;
   const snapshotAmount = snapshotData && snapshotData.allowanceAmount;
@@ -1345,9 +1372,43 @@ const defaultRumahList = baseRumah
 
   const SAVE_RETRY_DELAYS = [0, 500, 1500];
   async function saveData(payload){
-    const endpoint = (typeof window !== 'undefined' && typeof window.ENV_SAVE_URL === 'string' && window.ENV_SAVE_URL.trim())
-      ? window.ENV_SAVE_URL.trim()
-      : '/.netlify/functions/save';
+    let client;
+    try {
+      client = await ensureApiClient();
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      console.error('Gagal menyiapkan API client', error);
+      throw error;
+    }
+
+    if (!client || typeof client.createRequest !== 'function'){
+      const missing = new Error('Konfigurasi backend tidak tersedia');
+      console.error('saveData: API client hilang', missing);
+      throw missing;
+    }
+
+    const payloadIsObject = payload && typeof payload === 'object';
+    const forceNew = Boolean(payloadIsObject && payload.meta && payload.meta.forceNew);
+    const lastMeta = (typeof window !== 'undefined' && window.__upahLastSnapshotMeta && typeof window.__upahLastSnapshotMeta === 'object')
+      ? window.__upahLastSnapshotMeta
+      : null;
+    const lastKeyRaw = lastMeta && typeof lastMeta.snapshotKey === 'string' ? lastMeta.snapshotKey.trim() : '';
+    const hasExistingKey = Boolean(lastKeyRaw);
+    const shouldCreateNew = forceNew || !hasExistingKey;
+    const targetKey = shouldCreateNew ? null : lastKeyRaw;
+
+    const requestBody = payloadIsObject ? { ...payload } : payload;
+    if (requestBody && typeof requestBody === 'object'){
+      if (shouldCreateNew){
+        delete requestBody.key;
+      } else if (targetKey){
+        requestBody.key = targetKey;
+      }
+    }
+
+    const requestLabel = shouldCreateNew ? 'save' : 'update';
+    const requestMethod = shouldCreateNew ? 'POST' : 'PUT';
+    const requestQuery = { new: shouldCreateNew ? '1' : '0' };
 
     let lastError = null;
 
@@ -1355,13 +1416,29 @@ const defaultRumahList = baseRumah
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), 10000);
       try {
-        const response = await fetch(endpoint, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(payload),
-          signal: controller.signal,
-          mode: 'cors'
-        });
+        let requestConfig;
+        try {
+          requestConfig = client.createRequest(requestLabel, {
+            method: requestMethod,
+            body: requestBody,
+            query: requestQuery,
+          });
+        } catch (configErr) {
+          const error = configErr instanceof Error ? configErr : new Error(String(configErr));
+          error.retryable = false;
+          throw error;
+        }
+
+        const fetchInit = { ...requestConfig.init, signal: controller.signal };
+        if (requestConfig.init && requestConfig.init.headers){
+          if (requestConfig.init.headers instanceof Headers){
+            fetchInit.headers = new Headers(requestConfig.init.headers);
+          } else {
+            fetchInit.headers = { ...requestConfig.init.headers };
+          }
+        }
+
+        const response = await fetch(requestConfig.url, fetchInit);
         clearTimeout(timeoutId);
 
         const rawBody = await response.text();
@@ -1394,12 +1471,16 @@ const defaultRumahList = baseRumah
         clearTimeout(timeoutId);
         const error = err && err.name === 'AbortError'
           ? Object.assign(new Error('Permintaan kedaluwarsa setelah 10 detik'), { name: err.name })
-          : err;
+          : err instanceof Error ? err : new Error(String(err));
         console.error('saveData attempt failed', error);
         lastError = error;
 
         const status = typeof error?.status === 'number' ? error.status : null;
-        const retryable = error.name === 'AbortError' || status === null || status >= 500;
+        let retryable = error.name === 'AbortError' || status === null || status >= 500;
+        if (error && error.retryable === false){
+          retryable = false;
+        }
+
         if (attempt < SAVE_RETRY_DELAYS.length - 1 && retryable){
           const delay = SAVE_RETRY_DELAYS[attempt + 1];
           if (delay){

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,6 +7,12 @@
   external_node_modules = ["@netlify/blobs"]
 
 [[redirects]]
-  from = "/api/save"
-  to = "/.netlify/functions/save"
+  from = "/api/*"
+  to = "/.netlify/functions/api/:splat"
   status = 200
+
+[template.environment]
+  DATA_BACKEND = "NETLIFY_FN"
+  WEBAPP_URL = "https://script.google.com/macros/s/YOUR-WEBAPP-ID/exec"
+  API_KEY = "optional-apps-script-api-key"
+  SHEET_ID = "optional-spreadsheet-id"

--- a/netlify/functions/api.js
+++ b/netlify/functions/api.js
@@ -1,0 +1,354 @@
+import { getStore } from "@netlify/blobs";
+import { randomUUID } from "node:crypto";
+
+const NORMALIZED_ENV_ORIGINS = [
+  process.env.ALLOWED_ORIGIN,
+  process.env.DEPLOY_URL,
+  process.env.DEPLOY_PRIME_URL,
+  process.env.URL,
+  process.env.NETLIFY_DEV_SERVER_URL,
+]
+  .map((value) => (typeof value === "string" ? value.trim() : ""))
+  .filter(Boolean);
+
+const ALLOWED_ORIGINS = NORMALIZED_ENV_ORIGINS;
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Methods": "GET,POST,PUT,DELETE,OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization, X-API-KEY, X-SHEET-ID",
+  Vary: "Origin",
+};
+
+const JSON_HEADERS = {
+  "content-type": "application/json; charset=utf-8",
+  "cache-control": "no-store",
+};
+
+const TEXT_HEADERS = {
+  "content-type": "text/plain; charset=utf-8",
+  "cache-control": "no-store",
+};
+
+function withCors(init = {}, origin) {
+  const headers = new Headers(init.headers || {});
+  let allowedOriginHeader = "";
+
+  if (origin && ALLOWED_ORIGINS.includes(origin)) {
+    allowedOriginHeader = origin;
+  } else if (!origin && ALLOWED_ORIGINS.length > 0) {
+    allowedOriginHeader = ALLOWED_ORIGINS[0];
+  }
+
+  if (allowedOriginHeader) {
+    headers.set("Access-Control-Allow-Origin", allowedOriginHeader);
+  }
+
+  Object.entries(CORS_HEADERS).forEach(([key, value]) => {
+    if (!headers.has(key)) {
+      headers.set(key, value);
+    }
+  });
+
+  return headers;
+}
+
+function jsonResponse(body, init = {}, origin) {
+  const headers = withCors({ headers: { ...JSON_HEADERS, ...(init.headers || {}) } }, origin);
+  return new Response(JSON.stringify(body), { ...init, headers });
+}
+
+function textResponse(body, init = {}, origin) {
+  const headers = withCors({ headers: { ...TEXT_HEADERS, ...(init.headers || {}) } }, origin);
+  return new Response(body, { ...init, headers });
+}
+
+function isOriginAllowed(origin) {
+  if (!origin) return true;
+  const allowed = ALLOWED_ORIGINS.includes(origin);
+  if (!allowed) {
+    console.error("api-function: blocked origin", { origin, allowedOrigins: ALLOWED_ORIGINS });
+  }
+  return allowed;
+}
+
+function buildErrorBody(error, details) {
+  return { ok: false, error, ...(details === undefined ? {} : { details }) };
+}
+
+function safeMeta(meta) {
+  if (!meta || typeof meta !== "object") return {};
+  try {
+    return JSON.parse(JSON.stringify(meta));
+  } catch (error) {
+    const result = {};
+    Object.entries(meta).forEach(([key, value]) => {
+      if (value === undefined) return;
+      if (value === null || ["string", "number", "boolean"].includes(typeof value)) {
+        result[key] = value;
+      }
+    });
+    return result;
+  }
+}
+
+function createId() {
+  try {
+    return randomUUID();
+  } catch (error) {
+    return Math.random().toString(36).slice(2);
+  }
+}
+
+function extractIdFromSnapshotKey(key) {
+  if (typeof key !== "string") return null;
+  const match = key.match(/^snapshot:(.+)\.html$/);
+  return match ? match[1] : null;
+}
+
+function buildRecordKeyFromId(id) {
+  return `record:${id}.json`;
+}
+
+function buildSnapshotKeyFromId(id) {
+  return `snapshot:${id}.html`;
+}
+
+async function getRecord(store, snapshotKey) {
+  const id = extractIdFromSnapshotKey(snapshotKey);
+  if (!id) return null;
+  const recordKey = buildRecordKeyFromId(id);
+  try {
+    const record = await store.get(recordKey, { type: "json" });
+    if (!record || typeof record !== "object") return null;
+    return {
+      id,
+      recordKey,
+      snapshotKey,
+      createdAt: record.createdAt ?? null,
+      updatedAt: record.updatedAt ?? record.createdAt ?? null,
+      meta: record.meta && typeof record.meta === "object" ? record.meta : {},
+    };
+  } catch (error) {
+    console.error("api-function: gagal membaca record", { snapshotKey, error });
+    return null;
+  }
+}
+
+async function listRecords(store) {
+  const { blobs } = await store.list({ prefix: "record:" });
+  const items = [];
+  for (const blob of blobs) {
+    const raw = await store.get(blob.key, { type: "json" }).catch((error) => {
+      console.error("api-function: gagal parsing record", { key: blob.key, error });
+      return null;
+    });
+    if (!raw || typeof raw !== "object") continue;
+    const id = typeof raw.id === "string" ? raw.id : extractIdFromSnapshotKey(raw.snapshotKey);
+    const snapshotKey = typeof raw.snapshotKey === "string" ? raw.snapshotKey : id ? buildSnapshotKeyFromId(id) : null;
+    if (!snapshotKey) continue;
+    items.push({
+      id: id || extractIdFromSnapshotKey(snapshotKey) || null,
+      recordKey: blob.key,
+      snapshotKey,
+      createdAt: raw.createdAt ?? null,
+      updatedAt: raw.updatedAt ?? raw.createdAt ?? null,
+      meta: raw.meta && typeof raw.meta === "object" ? raw.meta : {},
+    });
+  }
+  items.sort((a, b) => {
+    const aTime = a.updatedAt || a.createdAt || "";
+    const bTime = b.updatedAt || b.createdAt || "";
+    return String(bTime).localeCompare(String(aTime));
+  });
+  return items;
+}
+
+async function handleList(store, origin) {
+  const items = await listRecords(store);
+  return jsonResponse({ ok: true, items, count: items.length }, { status: 200 }, origin);
+}
+
+async function handleItem(store, url, origin) {
+  const key = url.searchParams.get("key");
+  if (!key) {
+    return jsonResponse(buildErrorBody("Missing key"), { status: 400 }, origin);
+  }
+  const record = await getRecord(store, key);
+  if (!record) {
+    return jsonResponse(buildErrorBody("Snapshot not found"), { status: 404 }, origin);
+  }
+  const html = await store.get(record.snapshotKey, { type: "text" }).catch(() => null);
+  return jsonResponse({ ok: true, item: { ...record, html } }, { status: 200 }, origin);
+}
+
+async function handleSave(store, request, origin) {
+  let payload;
+  try {
+    payload = await request.json();
+  } catch (error) {
+    return jsonResponse(buildErrorBody("Invalid JSON body", { message: error.message }), { status: 400 }, origin);
+  }
+  const html = payload && typeof payload.html === "string" ? payload.html : "";
+  if (!html.trim()) {
+    return jsonResponse(buildErrorBody("Missing HTML payload"), { status: 400 }, origin);
+  }
+  const meta = safeMeta(payload.meta);
+  const id = `${Date.now()}-${createId()}`;
+  const snapshotKey = buildSnapshotKeyFromId(id);
+  const recordKey = buildRecordKeyFromId(id);
+  const createdAt = new Date().toISOString();
+  const record = {
+    id,
+    snapshotKey,
+    createdAt,
+    updatedAt: createdAt,
+    meta,
+  };
+  try {
+    await store.set(snapshotKey, html, { metadata: { createdAt, updatedAt: createdAt } });
+    await store.setJSON(recordKey, record, { metadata: { snapshotKey, createdAt, updatedAt: createdAt } });
+    return jsonResponse(
+      { ok: true, key: snapshotKey, snapshotKey, recordKey, createdAt, updatedAt: createdAt, meta },
+      { status: 201 },
+      origin,
+    );
+  } catch (error) {
+    console.error("api-function: gagal menyimpan snapshot", { error });
+    return jsonResponse(buildErrorBody("Failed to persist snapshot", { message: error.message }), { status: 500 }, origin);
+  }
+}
+
+async function handleUpdate(store, request, origin) {
+  let payload;
+  try {
+    payload = await request.json();
+  } catch (error) {
+    return jsonResponse(buildErrorBody("Invalid JSON body", { message: error.message }), { status: 400 }, origin);
+  }
+  const key = payload && typeof payload.key === "string" ? payload.key.trim() : "";
+  if (!key) {
+    return jsonResponse(buildErrorBody("Missing key"), { status: 400 }, origin);
+  }
+  const record = await getRecord(store, key);
+  if (!record) {
+    return jsonResponse(buildErrorBody("Snapshot not found"), { status: 404 }, origin);
+  }
+  const html = payload && typeof payload.html === "string" ? payload.html : "";
+  if (!html.trim()) {
+    return jsonResponse(buildErrorBody("Missing HTML payload"), { status: 400 }, origin);
+  }
+  const meta = safeMeta(payload.meta ?? record.meta ?? {});
+  const updatedAt = new Date().toISOString();
+  try {
+    await store.set(record.snapshotKey, html, { metadata: { createdAt: record.createdAt ?? updatedAt, updatedAt } });
+    await store.setJSON(record.recordKey, { ...record, meta, updatedAt }, {
+      metadata: { snapshotKey: record.snapshotKey, createdAt: record.createdAt ?? updatedAt, updatedAt },
+    });
+    return jsonResponse(
+      {
+        ok: true,
+        key: record.snapshotKey,
+        snapshotKey: record.snapshotKey,
+        recordKey: record.recordKey,
+        createdAt: record.createdAt,
+        updatedAt,
+        meta,
+      },
+      { status: 200 },
+      origin,
+    );
+  } catch (error) {
+    console.error("api-function: gagal memperbarui snapshot", { key: record.snapshotKey, error });
+    return jsonResponse(buildErrorBody("Failed to update snapshot", { message: error.message }), { status: 500 }, origin);
+  }
+}
+
+async function handleRemove(store, request, url, origin) {
+  let key = url.searchParams.get("key");
+  if (!key) {
+    try {
+      const body = await request.json();
+      if (body && typeof body.key === "string") {
+        key = body.key.trim();
+      }
+    } catch (_error) {
+      // ignore JSON parse errors for DELETE without body
+    }
+  }
+  if (!key) {
+    return jsonResponse(buildErrorBody("Missing key"), { status: 400 }, origin);
+  }
+  const record = await getRecord(store, key);
+  if (!record) {
+    return jsonResponse(buildErrorBody("Snapshot not found"), { status: 404 }, origin);
+  }
+  try {
+    await store.delete(record.snapshotKey);
+    await store.delete(record.recordKey);
+    return jsonResponse(
+      { ok: true, key: record.snapshotKey, snapshotKey: record.snapshotKey, removed: true },
+      { status: 200 },
+      origin,
+    );
+  } catch (error) {
+    console.error("api-function: gagal menghapus snapshot", { key: record.snapshotKey, error });
+    return jsonResponse(buildErrorBody("Failed to remove snapshot", { message: error.message }), { status: 500 }, origin);
+  }
+}
+
+function resolveAction(url) {
+  const segments = url.pathname.split("/").filter(Boolean);
+  const idx = segments.lastIndexOf("api");
+  const actionSegment = idx >= 0 ? segments[idx + 1] : segments[0];
+  return (actionSegment || "").toLowerCase();
+}
+
+export default async (request) => {
+  const origin = request.headers.get("origin");
+
+  if (!isOriginAllowed(origin)) {
+    return jsonResponse(buildErrorBody("Origin Not Allowed"), { status: 403 }, origin);
+  }
+
+  if (request.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: withCors({}, origin) });
+  }
+
+  const url = new URL(request.url);
+  const action = resolveAction(url);
+  const store = getStore("upah20");
+
+  try {
+    if (!action) {
+      if (request.method === "GET") {
+        return jsonResponse({ ok: true, message: "Upah Tukang API" }, { status: 200 }, origin);
+      }
+      return jsonResponse(buildErrorBody("Not Found"), { status: 404 }, origin);
+    }
+
+    if (action === "list" && request.method === "GET") {
+      return await handleList(store, origin);
+    }
+
+    if (action === "item" && request.method === "GET") {
+      return await handleItem(store, url, origin);
+    }
+
+    if (action === "save" && request.method === "POST") {
+      return await handleSave(store, request, origin);
+    }
+
+    if (action === "update" && request.method === "PUT") {
+      return await handleUpdate(store, request, origin);
+    }
+
+    if (action === "remove" && request.method === "DELETE") {
+      return await handleRemove(store, request, url, origin);
+    }
+
+    return jsonResponse(buildErrorBody("Method Not Allowed"), { status: 405 }, origin);
+  } catch (error) {
+    console.error("api-function: unhandled error", { action, method: request.method, error });
+    return jsonResponse(buildErrorBody("Internal Server Error", { message: error.message }), { status: 500 }, origin);
+  }
+};


### PR DESCRIPTION
## Summary
- add a configuration helper module that reads runtime environment values and builds API requests
- refactor the form submission logic to route snapshot saves through the helper and support Netlify or Apps Script backends
- implement a unified Netlify API function with blob storage persistence, update routing, and document the setup steps for both backends

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1f082d3088333bda9225edf98feea