### PR TITLE
Add shared export helpers and XLSX downloads

### DIFF
--- a/assets/js/export-utils.js
+++ b/assets/js/export-utils.js
@@ -1,0 +1,563 @@
+(function(global){
+  'use strict';
+
+  const DEFAULT_DAY_KEYS = ['Senin','Selasa','Rabu','Kamis','Jumat','Sabtu','Minggu'];
+  const DEFAULT_DISPLAY_ORDER = [6,0,1,2,3,4,5];
+  const DEFAULT_ALLOWANCE_THRESHOLD = 3.9;
+  const DEFAULT_ALLOWANCE_AMOUNT = 20000;
+
+  function calcDayWeight(label){
+    if (!label) return 0;
+    const str = String(label).trim();
+    if (!str) return 0;
+    if (str === '1/2 Lain') return 0.5;
+    if (/^1\/2\b/i.test(str)) return 0.5;
+    return 1;
+  }
+
+  function normalizeRows(rows){
+    if (!Array.isArray(rows)) return [];
+    return rows.map((row)=>{
+      const rumah = Array.isArray(row && row.rumah) ? row.rumah.slice(0, 7) : [];
+      const normalizedRumah = [];
+      for (let i=0; i<7; i++){
+        normalizedRumah[i] = rumah[i] ? String(rumah[i]) : '';
+      }
+      const bonusRaw = row && row.bonus !== undefined ? row.bonus : '';
+      const bonusStr = bonusRaw == null ? '' : String(bonusRaw);
+      return {
+        nama: row && row.nama != null ? String(row.nama) : '',
+        kelas: row && row.kelas != null ? String(row.kelas) : '',
+        group: row && row.group != null ? String(row.group) : '',
+        rumah: normalizedRumah,
+        ket: row && row.ket != null ? String(row.ket) : '',
+        bonus: bonusStr
+      };
+    });
+  }
+
+  function normalizeClassRates(classRates){
+    const out = { Senior: 0, Tukang: 0, Kenek: 0 };
+    if (classRates && typeof classRates === 'object'){
+      for (const k of Object.keys(classRates)){
+        const v = Number(classRates[k]);
+        if (Number.isFinite(v)) out[k] = v;
+      }
+    }
+    return out;
+  }
+
+  function normalizeRumah(list){
+    if (!Array.isArray(list)) return [];
+    return list.map((item)=> item == null ? '' : String(item)).filter((item)=> item !== '');
+  }
+
+  function normalizeDataset(dataset, overrides){
+    const src = dataset && typeof dataset === 'object' ? dataset : {};
+    const rows = normalizeRows(src.rows || src.data || []);
+    const classRates = normalizeClassRates(src.classRates || {});
+    const rumah = normalizeRumah(src.rumah || []);
+    const allowanceThresholdRaw = overrides && overrides.allowanceThreshold !== undefined
+      ? overrides.allowanceThreshold : (src.allowanceThreshold !== undefined ? src.allowanceThreshold : src.threshold);
+    const allowanceAmountRaw = overrides && overrides.allowanceAmount !== undefined
+      ? overrides.allowanceAmount : (src.allowanceAmount !== undefined ? src.allowanceAmount : src.allowance);
+    const allowanceThreshold = Number(allowanceThresholdRaw);
+    const allowanceAmount = Number(allowanceAmountRaw);
+    const dayKeys = Array.isArray(src.dayKeys) ? src.dayKeys.map((d)=> d == null ? '' : String(d)) : DEFAULT_DAY_KEYS.slice();
+    const displayDayOrder = Array.isArray(src.displayDayOrder) && src.displayDayOrder.length === 7
+      ? src.displayDayOrder.map((n)=> Number.isInteger(n) ? n : 0)
+      : DEFAULT_DISPLAY_ORDER.slice();
+
+    const periodStart = overrides && overrides.periodStart !== undefined ? overrides.periodStart : (src.periode ?? src.periodStart ?? '');
+    const periodEnd = overrides && overrides.periodEnd !== undefined ? overrides.periodEnd : (src.sd ?? src.periodEnd ?? '');
+
+    const meta = Object.assign({ source: src.__source || 'manual' }, overrides && overrides.meta ? overrides.meta : {});
+
+    return {
+      rows,
+      classRates,
+      rumah,
+      allowanceThreshold: Number.isFinite(allowanceThreshold) ? allowanceThreshold : DEFAULT_ALLOWANCE_THRESHOLD,
+      allowanceAmount: Number.isFinite(allowanceAmount) ? allowanceAmount : DEFAULT_ALLOWANCE_AMOUNT,
+      dayKeys,
+      displayDayOrder,
+      periodStart: periodStart == null ? '' : String(periodStart),
+      periodEnd: periodEnd == null ? '' : String(periodEnd),
+      meta
+    };
+  }
+
+  function loadFromLegacy(){
+    try {
+      const rowsRaw = localStorage.getItem('upah20_rows');
+      const classRatesRaw = localStorage.getItem('upah20_classRates');
+      const rumahRaw = localStorage.getItem('upah20_rumah');
+      const thresholdRaw = localStorage.getItem('upah20_beras_threshold');
+      const amountRaw = localStorage.getItem('upah20_beras_amount');
+      const periodStart = localStorage.getItem('upah20_periodStart');
+      const periodEnd = localStorage.getItem('upah20_periodEnd');
+      const dataset = {
+        rows: rowsRaw ? JSON.parse(rowsRaw) : [],
+        classRates: classRatesRaw ? JSON.parse(classRatesRaw) : {},
+        rumah: rumahRaw ? JSON.parse(rumahRaw) : [],
+        allowanceThreshold: thresholdRaw ? Number(thresholdRaw) : undefined,
+        allowanceAmount: amountRaw ? Number(amountRaw) : undefined,
+        periode: periodStart || '',
+        sd: periodEnd || '',
+        __source: 'legacy'
+      };
+      if (!Array.isArray(dataset.rows)) dataset.rows = [];
+      if (!Array.isArray(dataset.rumah)) dataset.rumah = [];
+      if (!dataset.rows.length && !dataset.rumah.length && (!dataset.periode && !dataset.sd)){
+        return null;
+      }
+      return normalizeDataset(dataset, { meta: { source: 'legacy' } });
+    } catch (_err) {
+      return null;
+    }
+  }
+
+  function loadActiveDataset(){
+    let root = null;
+    try {
+      const raw = localStorage.getItem('upahTukang');
+      if (raw) root = JSON.parse(raw);
+    } catch (_){ root = null; }
+    if (!root || typeof root !== 'object') root = {};
+    const items = Array.isArray(root.items) ? root.items : [];
+    let active = null;
+    if (root.activeId){
+      active = items.find((item)=> item && item.id === root.activeId) || null;
+    }
+    if (!active && items.length){
+      active = items[items.length - 1];
+    }
+    if (active && typeof active === 'object'){
+      return normalizeDataset(active, {
+        periodStart: active.periode,
+        periodEnd: active.sd,
+        allowanceThreshold: active.allowanceThreshold,
+        allowanceAmount: active.allowanceAmount,
+        meta: {
+          source: 'storage',
+          id: active.id || null,
+          createdAt: active.createdAt || null,
+          updatedAt: active.updatedAt || null,
+          newIndex: active.newIndex || null
+        }
+      });
+    }
+    return loadFromLegacy();
+  }
+
+  function parseBonus(raw){
+    const str = raw == null ? '' : String(raw);
+    const cleaned = str.replace(/[^\d]/g, '');
+    const num = Number(cleaned);
+    return Number.isFinite(num) ? num : 0;
+  }
+
+  function rowComputation(row, ctx){
+    const rate = Number(ctx.classRates[row.kelas] || 0);
+    const hari = (row.rumah || []).reduce((sum, label)=> sum + calcDayWeight(label), 0);
+    const upahPokok = hari * rate;
+    const uangBeras = hari > ctx.allowanceThreshold ? ctx.allowanceAmount : 0;
+    const bonus = parseBonus(row.bonus);
+    const totalBayar = upahPokok + uangBeras + bonus;
+    return { rate, hari, upahPokok, uangBeras, bonus, totalBayar };
+  }
+
+  function buildSections(dataset){
+    const ctx = normalizeDataset(dataset);
+    const displayDayKeys = ctx.displayDayOrder.map((idx)=> ctx.dayKeys[idx] || '');
+
+    const detailHeader = ['No','Nama','Kelas','Group','Rate', ...displayDayKeys, 'Hari','Upah Pokok','Uang Beras','Total','Keterangan'];
+    const detailRows = ctx.rows.map((row, idx)=>{
+      const calc = rowComputation(row, ctx);
+      const dayValues = ctx.displayDayOrder.map((di)=> (row.rumah && row.rumah[di]) ? row.rumah[di] : '');
+      return [
+        idx + 1,
+        row.nama || '',
+        row.kelas || '',
+        row.group || '',
+        calc.rate,
+        ...dayValues,
+        calc.hari,
+        calc.upahPokok,
+        calc.uangBeras,
+        calc.totalBayar,
+        row.ket || ''
+      ];
+    });
+
+    const perRumahMap = new Map();
+    ctx.rows.forEach((row)=>{
+      const rate = Number(ctx.classRates[row.kelas] || 0);
+      for (let di=0; di<7; di++){
+        const label = row.rumah ? row.rumah[di] : '';
+        if (!label) continue;
+        const weight = calcDayWeight(label);
+        if (!weight) continue;
+        const key = label;
+        const current = perRumahMap.get(key) || { hari: 0, upah: 0 };
+        current.hari += weight;
+        current.upah += rate * weight;
+        perRumahMap.set(key, current);
+      }
+    });
+
+    const rumahSet = new Set(ctx.rumah);
+    const extraKeys = [];
+    perRumahMap.forEach((_, key)=>{ if (!rumahSet.has(key)) extraKeys.push(key); });
+    extraKeys.sort((a,b)=> a.localeCompare(b));
+    const orderedRumah = ctx.rumah.slice();
+    extraKeys.forEach((key)=>{ if (key) orderedRumah.push(key); });
+    if (!orderedRumah.length){
+      orderedRumah.push(...Array.from(perRumahMap.keys()).sort((a,b)=> a.localeCompare(b)));
+    }
+
+    let totalHariRumah = 0;
+    let totalUpahRumah = 0;
+    const perRumahRows = orderedRumah.map((name)=>{
+      const stat = perRumahMap.get(name) || { hari: 0, upah: 0 };
+      totalHariRumah += stat.hari;
+      totalUpahRumah += stat.upah;
+      return [name, stat.hari, stat.upah];
+    }).filter((row)=> row[0]);
+    if (!perRumahRows.length && perRumahMap.size){
+      perRumahMap.forEach((stat, name)=>{
+        totalHariRumah += stat.hari;
+        totalUpahRumah += stat.upah;
+        perRumahRows.push([name, stat.hari, stat.upah]);
+      });
+    }
+    if (perRumahRows.length){
+      perRumahRows.push(['TOTAL', totalHariRumah, totalUpahRumah]);
+    }
+
+    const perDayRows = [];
+    let totalHariWeek = 0;
+    let totalUpahWeek = 0;
+    ctx.displayDayOrder.forEach((di, idx)=>{
+      const label = displayDayKeys[idx] || `Hari ${idx+1}`;
+      let hari = 0;
+      let upah = 0;
+      ctx.rows.forEach((row)=>{
+        const value = row.rumah ? row.rumah[di] : '';
+        if (!value) return;
+        const weight = calcDayWeight(value);
+        if (!weight) return;
+        const rate = Number(ctx.classRates[row.kelas] || 0);
+        hari += weight;
+        upah += rate * weight;
+      });
+      totalHariWeek += hari;
+      totalUpahWeek += upah;
+      perDayRows.push([label, hari, upah]);
+    });
+    if (perDayRows.length){
+      perDayRows.push(['TOTAL', totalHariWeek, totalUpahWeek]);
+    }
+
+    const sections = [
+      { title: 'Detail Pekerja', header: detailHeader, rows: detailRows },
+      { title: 'Rekap Total per Rumah', header: ['Rumah','Total Hari','Total Upah'], rows: perRumahRows },
+      { title: 'Rekap Total per Hari', header: ['Tanggal','Total Hari','Total Upah'], rows: perDayRows }
+    ];
+
+    const meta = {
+      generatedAt: new Date().toISOString(),
+      rowsCount: ctx.rows.length,
+      periodStart: ctx.periodStart,
+      periodEnd: ctx.periodEnd
+    };
+
+    return { sections, meta, context: ctx };
+  }
+
+  function csvEscape(value){
+    if (value === null || value === undefined) return '';
+    const str = String(value);
+    if (/[",\n\r]/.test(str)){
+      return '"' + str.replace(/"/g, '""') + '"';
+    }
+    return str;
+  }
+
+  function sectionsToCSV(sections){
+    const lines = [];
+    sections.forEach((section, idx)=>{
+      if (!section) return;
+      if (idx > 0) lines.push('');
+      if (section.title) lines.push(csvEscape(section.title));
+      if (section.header) lines.push(section.header.map(csvEscape).join(','));
+      if (Array.isArray(section.rows)){
+        section.rows.forEach((row)=>{
+          lines.push(row.map(csvEscape).join(','));
+        });
+      }
+    });
+    return lines.join('\r\n');
+  }
+
+  function escapeXml(str){
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&apos;');
+  }
+
+  function columnLetter(idx){
+    let n = idx;
+    let letters = '';
+    while (n > 0){
+      const mod = (n - 1) % 26;
+      letters = String.fromCharCode(65 + mod) + letters;
+      n = Math.floor((n - 1) / 26);
+    }
+    return letters || 'A';
+  }
+
+  function aoaToSheetXml(section){
+    const rows = [];
+    const aoa = [];
+    aoa.push([section.title || '']);
+    aoa.push([]);
+    aoa.push(section.header || []);
+    if (Array.isArray(section.rows)){
+      section.rows.forEach((row)=> aoa.push(row));
+    }
+    let maxCols = 0;
+    aoa.forEach((row)=>{ if (row && row.length > maxCols) maxCols = row.length; });
+    if (maxCols === 0) maxCols = 1;
+    const dimension = `A1:${columnLetter(maxCols)}${aoa.length}`;
+    aoa.forEach((row, rowIdx)=>{
+      const cells = [];
+      if (row && row.length){
+        row.forEach((value, colIdx)=>{
+          if (value === null || value === undefined || value === '') return;
+          const ref = `${columnLetter(colIdx + 1)}${rowIdx + 1}`;
+          if (typeof value === 'number'){
+            cells.push(`<c r="${ref}" t="n"><v>${value}</v></c>`);
+          } else {
+            cells.push(`<c r="${ref}" t="inlineStr"><is><t>${escapeXml(value)}</t></is></c>`);
+          }
+        });
+      }
+      if (cells.length){
+        rows.push(`<row r="${rowIdx + 1}">${cells.join('')}</row>`);
+      } else {
+        rows.push(`<row r="${rowIdx + 1}"/>`);
+      }
+    });
+    return `<?xml version="1.0" encoding="UTF-8"?>\n` +
+      `<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">` +
+      `<dimension ref="${dimension}"/>` +
+      `<sheetData>${rows.join('')}</sheetData>` +
+      `</worksheet>`;
+  }
+
+  function crc32(buf){
+    const table = crc32.table || (crc32.table = (function(){
+      const tbl = new Uint32Array(256);
+      for (let i=0; i<256; i++){
+        let c = i;
+        for (let j=0; j<8; j++){
+          c = (c & 1) ? (0xEDB88320 ^ (c >>> 1)) : (c >>> 1);
+        }
+        tbl[i] = c >>> 0;
+      }
+      return tbl;
+    })());
+    let crc = 0 ^ (-1);
+    for (let i=0; i<buf.length; i++){
+      crc = (crc >>> 8) ^ table[(crc ^ buf[i]) & 0xFF];
+    }
+    return (crc ^ (-1)) >>> 0;
+  }
+
+  function uint16LE(value){
+    const arr = new Uint8Array(2);
+    arr[0] = value & 0xFF;
+    arr[1] = (value >>> 8) & 0xFF;
+    return arr;
+  }
+
+  function uint32LE(value){
+    const arr = new Uint8Array(4);
+    arr[0] = value & 0xFF;
+    arr[1] = (value >>> 8) & 0xFF;
+    arr[2] = (value >>> 16) & 0xFF;
+    arr[3] = (value >>> 24) & 0xFF;
+    return arr;
+  }
+
+  function concatUint8(arrays){
+    const total = arrays.reduce((sum, arr)=> sum + arr.length, 0);
+    const out = new Uint8Array(total);
+    let offset = 0;
+    arrays.forEach((arr)=>{ out.set(arr, offset); offset += arr.length; });
+    return out;
+  }
+
+  function createZip(files){
+    const encoder = new TextEncoder();
+    const chunks = [];
+    const central = [];
+    let offset = 0;
+
+    files.forEach((file, index)=>{
+      const nameBytes = typeof file.name === 'string' ? encoder.encode(file.name) : file.name;
+      const dataBytes = typeof file.data === 'string' ? encoder.encode(file.data) : file.data;
+      const crc = crc32(dataBytes);
+      const localHeader = concatUint8([
+        uint32LE(0x04034b50),
+        uint16LE(20),
+        uint16LE(0),
+        uint16LE(0),
+        uint16LE(0),
+        uint16LE(0),
+        uint32LE(crc),
+        uint32LE(dataBytes.length),
+        uint32LE(dataBytes.length),
+        uint16LE(nameBytes.length),
+        uint16LE(0)
+      ]);
+      const localChunk = concatUint8([localHeader, nameBytes, dataBytes]);
+      chunks.push(localChunk);
+
+      const centralHeader = concatUint8([
+        uint32LE(0x02014b50),
+        uint16LE(0x0014),
+        uint16LE(20),
+        uint16LE(0),
+        uint16LE(0),
+        uint16LE(0),
+        uint32LE(crc),
+        uint32LE(dataBytes.length),
+        uint32LE(dataBytes.length),
+        uint16LE(nameBytes.length),
+        uint16LE(0),
+        uint16LE(0),
+        uint16LE(0),
+        uint16LE(0),
+        uint32LE(0),
+        uint32LE(offset)
+      ]);
+      central.push(concatUint8([centralHeader, nameBytes]));
+      offset += localChunk.length;
+    });
+
+    const centralDir = concatUint8(central);
+    const endRecord = concatUint8([
+      uint32LE(0x06054b50),
+      uint16LE(0),
+      uint16LE(0),
+      uint16LE(files.length),
+      uint16LE(files.length),
+      uint32LE(centralDir.length),
+      uint32LE(offset),
+      uint16LE(0)
+    ]);
+
+    return concatUint8([...chunks, centralDir, endRecord]);
+  }
+
+  function sectionsToXLSX(sections){
+    const sheetEntries = sections.map((section)=> aoaToSheetXml(section));
+    const files = [];
+    files.push({ name: '[Content_Types].xml', data: buildContentTypes(sheetEntries.length) });
+    files.push({ name: '_rels/.rels', data: buildRootRels() });
+    files.push({ name: 'xl/workbook.xml', data: buildWorkbookXml(sheetEntries.length, sections) });
+    files.push({ name: 'xl/_rels/workbook.xml.rels', data: buildWorkbookRels(sheetEntries.length) });
+    files.push({ name: 'xl/styles.xml', data: buildStylesXml() });
+    sheetEntries.forEach((xml, idx)=>{
+      files.push({ name: `xl/worksheets/sheet${idx+1}.xml`, data: xml });
+    });
+    return createZip(files);
+  }
+
+  function buildContentTypes(sheetCount){
+    const sheetOverrides = Array.from({length: sheetCount}, (_, idx)=>
+      `<Override PartName="/xl/worksheets/sheet${idx+1}.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>`
+    ).join('');
+    return `<?xml version="1.0" encoding="UTF-8"?>`
+      + `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">`
+      + `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>`
+      + `<Default Extension="xml" ContentType="application/xml"/>`
+      + `<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>`
+      + `<Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>`
+      + sheetOverrides
+      + `</Types>`;
+  }
+
+  function buildRootRels(){
+    return `<?xml version="1.0" encoding="UTF-8"?>`
+      + `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">`
+      + `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>`
+      + `</Relationships>`;
+  }
+
+  function sanitizeSheetName(name){
+    const raw = name == null ? '' : String(name);
+    const invalid = /[\\\*\?\[\]\/:]/g;
+    let cleaned = raw.replace(invalid, ' ').trim();
+    if (!cleaned) cleaned = 'Sheet';
+    if (cleaned.length > 31) cleaned = cleaned.slice(0, 31);
+    return cleaned;
+  }
+
+  function buildWorkbookXml(sheetCount, sections){
+    const sheetsXml = Array.from({length: sheetCount}, (_, idx)=>{
+      const title = sections[idx] && sections[idx].title ? sections[idx].title : `Sheet ${idx+1}`;
+      const name = escapeXml(sanitizeSheetName(title));
+      return `<sheet name="${name}" sheetId="${idx+1}" r:id="rId${idx+1}"/>`;
+    }).join('');
+    return `<?xml version="1.0" encoding="UTF-8"?>`
+      + `<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">`
+      + `<sheets>${sheetsXml}</sheets>`
+      + `</workbook>`;
+  }
+
+  function buildWorkbookRels(sheetCount){
+    const rels = Array.from({length: sheetCount}, (_, idx)=>
+      `<Relationship Id="rId${idx+1}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet${idx+1}.xml"/>`
+    ).join('')
+    + `<Relationship Id="rId${sheetCount+1}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>`;
+    return `<?xml version="1.0" encoding="UTF-8"?>`
+      + `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">`
+      + rels
+      + `</Relationships>`;
+  }
+
+  function buildStylesXml(){
+    return `<?xml version="1.0" encoding="UTF-8"?>`
+      + `<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">`
+      + `<fonts count="1"><font><sz val="11"/><color theme="1"/><name val="Calibri"/><family val="2"/></font></fonts>`
+      + `<fills count="2"><fill><patternFill patternType="none"/></fill><fill><patternFill patternType="gray125"/></fill></fills>`
+      + `<borders count="1"><border><left/><right/><top/><bottom/><diagonal/></border></borders>`
+      + `<cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>`
+      + `<cellXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/></cellXfs>`
+      + `<cellStyles count="1"><cellStyle name="Normal" xfId="0" builtinId="0"/></cellStyles>`
+      + `</styleSheet>`;
+  }
+
+  function timestampName(prefix, ext){
+    const d = new Date();
+    const pad = (n)=> String(n).padStart(2, '0');
+    const name = `${prefix}_${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}_${pad(d.getHours())}${pad(d.getMinutes())}`;
+    return `${name}.${ext}`;
+  }
+
+  global.UpahExport = {
+    calcDayWeight,
+    normalizeDataset,
+    buildSections,
+    sectionsToCSV,
+    sectionsToXLSX,
+    loadActiveDataset,
+    timestampName
+  };
+})(typeof window !== 'undefined' ? window : this);

--- a/form.html
+++ b/form.html
@@ -813,6 +813,7 @@
           <button class="btn btn-secondary" onclick="addWorker()">Tambah Pekerja</button>
           <button class="btn btn-secondary" onclick="window.print()">Cetak</button>
           <button class="btn btn-secondary" onclick="try{downloadCSV&&downloadCSV()}catch(_){alert('downloadCSV tidak ditemukan')}">Unduh CSV</button>
+          <button class="btn btn-secondary" onclick="try{downloadXLSX&&downloadXLSX()}catch(_){alert('downloadXLSX tidak ditemukan')}">Unduh XLSX</button>
           <button class="btn btn-secondary" onclick="try{downloadJSON&&downloadJSON()}catch(_){alert('downloadJSON tidak ditemukan')}">Unduh JSON</button>
           <button class="btn btn-secondary btn-sm" onclick="restoreDefaultRows()">Kosongkan</button>
         </div>
@@ -973,7 +974,9 @@
         </div>
       </div>
     </div>
-  </div>
+</div>
+
+<script src="assets/js/export-utils.js"></script>
 
 <script>
   // ===== Defaults =====
@@ -988,6 +991,17 @@ const defaultRumahList = baseRumah
   // Display order: Sunday first (Minggu, Senin ... Sabtu) mapped to internal indices (Mon..Sun)
   const displayDayOrder = [6,0,1,2,3,4,5];
   const displayDayKeys = displayDayOrder.map(i => dayKeys[i]);
+
+  const calcDayWeight = (window.UpahExport && typeof window.UpahExport.calcDayWeight === 'function')
+    ? window.UpahExport.calcDayWeight
+    : function(label){
+        if (!label) return 0;
+        const str = String(label).trim();
+        if (!str) return 0;
+        if (str === '1/2 Lain') return 0.5;
+        if (/^1\/2\b/i.test(str)) return 0.5;
+        return 1;
+      };
 
   let apiClientInstance = null;
   let apiClientLoader = null;
@@ -1695,13 +1709,9 @@ function groupRows(){
 }
 function rowCalc(r){
     const rate=Number(classRates[r.kelas]||0);
-    const hari = r.rumah.reduce((a,b)=> {
-      if(!b) return a;
-      const isHalf = (b==='1/2 Lain') || /^\s*1\/2\s+/.test(b);
-      return a + (isHalf ? 0.5 : 1);
-    }, 0);
-    
-const upahPokok = hari * rate;
+    const rumahVals = Array.isArray(r.rumah) ? r.rumah : [];
+    const hari = rumahVals.reduce((a,b)=> a + calcDayWeight(b), 0);
+    const upahPokok = hari * rate;
     const uangBeras = hari > allowanceThreshold ? allowanceAmount : 0;
     const bonus = Number((r.bonus??'').toString().replace(/[^\d]/g,''))||0;
     const totalBayar = upahPokok + uangBeras + bonus;
@@ -1902,10 +1912,12 @@ const upahPokok = hari * rate;
     const map = {};
     rows.forEach(r=>{
       const rate = Number(classRates[r.kelas]||0);
+      const rumahVals = Array.isArray(r.rumah) ? r.rumah : [];
       for(let di=0; di<7; di++){
-        const v = r.rumah[di];
+        const v = rumahVals[di];
         if(!v) continue;
-        const w = (v==='1/2 Lain') ? 0.5 : 1;
+        const w = calcDayWeight(v);
+        if(!w) continue;
         if(!map[v]) map[v] = {hari:0, upah:0};
         map[v].hari += w;
         map[v].upah += rate * w;
@@ -1917,10 +1929,11 @@ const upahPokok = hari * rate;
     const map = {}; // {Rumah: [{cnt, upah} x7]}
     rows.forEach(r=>{
       const rate = Number(classRates[r.kelas]||0);
+      const rumahVals = Array.isArray(r.rumah) ? r.rumah : [];
       for(let di=0; di<7; di++){
-        const v = r.rumah[di];
+        const v = rumahVals[di];
         if(!v) continue;
-        const w = (v==='1/2 Lain') ? 0.5 : 1;
+        const w = calcDayWeight(v);
         if(!map[v]) map[v] = Array.from({length:7}, ()=>({cnt:0, upah:0}));
         map[v][di].cnt += 1;
         map[v][di].upah += rate * w;
@@ -1988,12 +2001,6 @@ const upahPokok = hari * rate;
   }
 
   // ===== Export Helpers =====
-  function _csvEscape(v){
-    if(v===null || v===undefined) v = '';
-    v = String(v);
-    if (/[",\n]/.test(v)) return '"' + v.replace(/"/g, '""') + '"';
-    return v;
-  }
   function _timestampName(prefix, ext){
     const d = new Date();
     const pad = n => String(n).padStart(2,'0');
@@ -2083,42 +2090,54 @@ const upahPokok = hari * rate;
     }
   }
 
-  // Export CSV (tampilan tabel pekerja)
+  function _prepareExportSections(){
+    if (!window.UpahExport || typeof window.UpahExport.buildSections !== 'function'){
+      throw new Error('Fitur ekspor tidak tersedia.');
+    }
+    return window.UpahExport.buildSections({
+      rows,
+      classRates,
+      rumah,
+      allowanceThreshold,
+      allowanceAmount,
+      dayKeys,
+      displayDayOrder,
+      periode: activeItem ? (activeItem.periode || '') : '',
+      sd: activeItem ? (activeItem.sd || '') : ''
+    });
+  }
+
+  // Export CSV (tampilan tabel pekerja + rekap)
   function downloadCSV(){
     try{
-      const headers = [
-        'No','Nama','Kelas','Group','Rate',
-        ...displayDayKeys, 'Hari','Upah Pokok','Uang Beras','Total','Keterangan'
-      ];
-      const lines = [ headers.map(_csvEscape).join(',') ];
-
-      rows.forEach((r, idx)=>{
-        const calc = rowCalc(r);
-        const rowVals = [
-          idx+1,
-          r.nama||'',
-          r.kelas||'',
-          r.group||'',
-          calc.rate||0,
-          ...displayDayOrder.map(di=> (r.rumah||[])[di]||''),
-          calc.hari||0,
-          calc.upahPokok||0,
-          calc.uangBeras||0,
-          calc.totalBayar||0,
-          r.ket||''
-        ];
-        
-        lines.push(rowVals.map(_csvEscape).join(','));
-      });
-
-      const csv = lines.join('\r\n');
-      _downloadBlob(csv, 'text/csv;charset=utf-8', _timestampName('upah7hari', 'csv'));
+      const exportData = _prepareExportSections();
+      const csv = window.UpahExport.sectionsToCSV(exportData.sections);
+      const nameFn = window.UpahExport && typeof window.UpahExport.timestampName === 'function'
+        ? window.UpahExport.timestampName
+        : _timestampName;
+      _downloadBlob(csv, 'text/csv;charset=utf-8', nameFn('upah7hari', 'csv'));
     }catch(err){
       console.error(err);
       alert('Gagal mengekspor CSV: ' + err.message);
     }
   }
 
+  function downloadXLSX(){
+    try{
+      if (!window.UpahExport || typeof window.UpahExport.sectionsToXLSX !== 'function'){
+        throw new Error('Fitur XLSX tidak tersedia.');
+      }
+      const exportData = _prepareExportSections();
+      const workbook = window.UpahExport.sectionsToXLSX(exportData.sections);
+      const nameFn = window.UpahExport && typeof window.UpahExport.timestampName === 'function'
+        ? window.UpahExport.timestampName
+        : _timestampName;
+      _downloadBlob(workbook, 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', nameFn('upah7hari', 'xlsx'));
+    }catch(err){
+      console.error(err);
+      alert('Gagal mengekspor XLSX: ' + err.message);
+    }
+  }
 
 
   function setView(m){ viewMode = m; localStorage.setItem('upah20_viewMode', m); rerender(); }

--- a/rekap.html
+++ b/rekap.html
@@ -31,6 +31,7 @@
   </section>
 </main>
 </div>
+<script src="assets/js/export-utils.js"></script>
 <script>
   const KEY_HISTORY='upah20_period_history_v2', KEY_SEQ='upah20_new_sequence_counter';
   function load(){ try{return JSON.parse(localStorage.getItem(KEY_HISTORY))||[];}catch(_){return [];} }
@@ -38,6 +39,43 @@
   function getSeq(){ const v=parseInt(localStorage.getItem(KEY_SEQ)||'1',10); return isNaN(v)||v<1?1:v; }
   function setSeq(n){ localStorage.setItem(KEY_SEQ,String(n)); }
   function refreshBadge(){ document.getElementById('seqBadge').textContent='Next: ?new='+getSeq(); }
+  function downloadFile(content, mime, filename){
+    const blob = new Blob([content], {type: mime});
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    setTimeout(()=>URL.revokeObjectURL(url), 1500);
+  }
+  function exportFormDataAs(format){
+    if (!window.UpahExport){
+      alert('Fitur ekspor belum tersedia.');
+      return;
+    }
+    const dataset = (typeof window.UpahExport.loadActiveDataset === 'function')
+      ? window.UpahExport.loadActiveDataset()
+      : null;
+    if (!dataset){
+      alert('Data form tidak ditemukan. Buka form dan simpan terlebih dahulu.');
+      return;
+    }
+    const exportData = window.UpahExport.buildSections(dataset);
+    const nameFn = (typeof window.UpahExport.timestampName === 'function')
+      ? window.UpahExport.timestampName
+      : ((prefix, ext)=> `${prefix}.${ext}`);
+    if (format === 'xlsx'){
+      if (typeof window.UpahExport.sectionsToXLSX !== 'function'){
+        alert('Ekspor XLSX tidak tersedia.');
+        return;
+      }
+      const workbook = window.UpahExport.sectionsToXLSX(exportData.sections);
+      downloadFile(workbook, 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', nameFn('upah7hari', 'xlsx'));
+      return;
+    }
+    const csv = window.UpahExport.sectionsToCSV(exportData.sections);
+    downloadFile(csv, 'text/csv;charset=utf-8', nameFn('upah7hari', 'csv'));
+  }
   function render(){
     let arr=load(); const order=document.getElementById('order').value||'desc'; const tbody=document.getElementById('tbody'); tbody.innerHTML='';
     if(!arr.length){ tbody.innerHTML='<tr class="empty-state"><td colspan="5">Belum ada data. Buka form, isi & tekan <b>Simpan</b>.</td></tr>'; document.getElementById('counter').textContent='0 periode'; document.getElementById('grand').textContent='Rp 0'; return; }
@@ -68,11 +106,13 @@
   document.getElementById('btnReload').addEventListener('click', render);
   document.getElementById('order').addEventListener('change', render);
   document.getElementById('btnExport').addEventListener('click', ()=>{
-    const arr=load(); if(!arr.length) return alert('Tidak ada data.');
-    const head=['Periode Mulai','Periode Selesai','Total Bayar Periode'];
-    const rows=[head].concat(arr.map(r=>[r.periodeMulai||'', r.periodeSelesai||'', (r.sumTotal||0)]));
-    const csv=rows.map(r=>r.map(x=>`"${String(x).replace(/"/g,'""')}"`).join(',')).join('\n');
-    const blob=new Blob([csv],{type:'text/csv;charset=utf-8'}); 
+    try {
+      exportFormDataAs('csv');
+    } catch(err){
+      console.error(err);
+      alert('Gagal mengekspor data.');
+    }
+  });
 
 // === Import CSV (merge to history) ===
 document.getElementById('btnImport').addEventListener('click', ()=>{
@@ -138,9 +178,6 @@ document.getElementById('imp').addEventListener('change', async (e)=>{
   }
 });
 
-const url=URL.createObjectURL(blob); const a=document.createElement('a'); a.href=url; a.download='rekap-periode-total-bayar.csv'; a.click(); URL.revokeObjectURL(url);
-  });
-  
 // Auto-refresh when page gains focus, becomes visible, restored from BFCache, or storage changes in another tab
 window.addEventListener('focus', render);
 document.addEventListener('visibilitychange', ()=>{ if(!document.hidden) render(); });


### PR DESCRIPTION
## Summary
- add a shared export utility to normalize datasets and build CSV/XLSX tables for workers, per-rumah, and per-hari recaps
- update form exports to use the shared helper, bundle all recap sections in one CSV, and expose a new XLSX download button
- switch the rekap page export to reuse the shared export payload so it matches the form output

## Testing
- node - <<'NODE' … (smoke test for UpahExport sections)


------
https://chatgpt.com/codex/tasks/task_e_68e1f4b63cec833383cb212f104608d4